### PR TITLE
FIX - fixed events.tsv, which had an empty first header line element …

### DIFF
--- a/ds101/sub-01/func/sub-01_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-01/func/sub-01_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	692	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	624	n/a
-2	5.0	1.0	congruent_correct	n/a	1	1	congruent	1477	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	578	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	609	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	518	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	343	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	483	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	345	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	512	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	383	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	515	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	423	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	425	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	382	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	412	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	447	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	311	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	330	n/a
-27	87.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	384	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	467	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	497	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	402	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	358	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	370	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	356	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	499	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	317	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	579	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	375	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	398	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	390	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	337	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	374	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	365	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	330	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	406	n/a
-58	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	556	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	552	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	369	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	397	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	385	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	893	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	400	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	667	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	448	n/a
-76	235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	353	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	325	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	412	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	369	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	493	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	574	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	339	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	551	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	365	n/a
-86	270.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	549	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
-89	277.5	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	454	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	395	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	489	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	506	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	399	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	692	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	624	n/a
+5.0	1.0	congruent_correct	n/a	1	1	congruent	1477	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	578	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	609	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	518	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	343	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	483	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	345	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	512	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	383	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	515	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	423	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	425	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	382	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	412	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	447	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	311	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	330	n/a
+87.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	384	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	467	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	497	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	402	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	358	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	370	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	356	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	499	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	317	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	579	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	375	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	398	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	390	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	337	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	374	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	365	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	330	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	406	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	556	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	552	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	369	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	397	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	385	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	893	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	400	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	667	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	448	n/a
+235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	353	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	325	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	412	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	369	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	493	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	574	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	339	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	551	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	365	n/a
+270.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	549	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
+277.5	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	454	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	395	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	489	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	506	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	399	n/a

--- a/ds101/sub-01/func/sub-01_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-01/func/sub-01_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	494	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	714	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	475	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	534	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	377	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	459	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	423	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	438	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	505	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	395	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	432	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	395	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	475	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	319	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	476	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	522	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	600	n/a
-28	90.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	670	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	588	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	592	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	627	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	662	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	635	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	610	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	645	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	607	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	647	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	372	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	505	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	313	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	356	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	392	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	532	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	356	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	384	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	347	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	359	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	412	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	401	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	694	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	356	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	640	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	481	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	349	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	402	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	415	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	428	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	726	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	339	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	367	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	573	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	521	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	383	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	508	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	321	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	436	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	433	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	471	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	499	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	425	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	539	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	448	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	511	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	483	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	418	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	557	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	535	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	485	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	466	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	494	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	714	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	475	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	534	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	377	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	459	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	423	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	438	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	505	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	395	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	432	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	395	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	475	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	319	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	476	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	522	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	600	n/a
+90.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	670	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	588	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	592	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	627	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	662	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	635	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	610	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	645	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	607	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	647	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	372	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	505	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	313	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	356	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	392	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	532	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	356	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	384	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	347	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	359	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	412	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	401	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	694	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	356	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	640	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	481	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	349	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	402	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	415	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	428	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	726	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	339	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	367	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	573	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	521	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	383	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	508	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	321	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	436	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	433	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	471	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	499	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	425	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	539	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	448	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	511	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	483	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	418	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	557	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	535	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	485	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	466	n/a

--- a/ds101/sub-02/func/sub-02_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-02/func/sub-02_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	1	2	incongruent	440	n/a
-1	2.5	1.0	incongruent_correct	1	2	incongruent	413	n/a
-2	5.0	1.0	congruent_incorrect	0	1	congruent	417	n/a
-3	7.5	1.0	congruent_correct	1	1	congruent	374	n/a
-4	10.0	1.0	incongruent_correct	1	2	incongruent	371	n/a
-5	12.5	1.0	incongruent_correct	1	2	incongruent	382	n/a
-6	20.0	1.0	incongruent_correct	1	2	incongruent	478	n/a
-7	22.5	1.0	incongruent_correct	1	2	incongruent	345	n/a
-8	25.0	1.0	congruent_correct	1	1	congruent	448	n/a
-9	27.5	1.0	congruent_correct	1	1	congruent	323	n/a
-10	30.0	1.0	congruent_correct	1	1	congruent	440	n/a
-11	32.5	1.0	congruent_correct	1	1	congruent	300	n/a
-12	45.0	1.0	congruent_correct	1	1	congruent	420	n/a
-13	47.5	1.0	congruent_correct	1	1	congruent	298	n/a
-14	50.0	1.0	incongruent_correct	1	2	incongruent	421	n/a
-15	52.5	1.0	incongruent_correct	1	2	incongruent	305	n/a
-16	55.0	1.0	congruent_incorrect	0	1	congruent	399	n/a
-17	57.5	1.0	incongruent_correct	1	2	incongruent	533	n/a
-18	65.0	1.0	congruent_incorrect	0	1	congruent	553	n/a
-19	67.5	1.0	incongruent_correct	1	2	incongruent	398	n/a
-20	70.0	1.0	incongruent_correct	1	2	incongruent	442	n/a
-21	72.5	1.0	incongruent_correct	1	2	incongruent	415	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	484	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	400	n/a
-24	80.0	1.0	congruent_correct	1	1	congruent	509	n/a
-25	82.5	1.0	congruent_correct	1	1	congruent	363	n/a
-26	85.0	1.0	congruent_correct	1	1	congruent	383	n/a
-27	87.5	1.0	incongruent_correct	1	2	incongruent	707	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	441	n/a
-29	92.5	1.0	congruent_correct	1	1	congruent	476	n/a
-30	95.0	1.0	incongruent_correct	1	2	incongruent	345	n/a
-31	97.5	1.0	incongruent_correct	1	2	incongruent	374	n/a
-32	100.0	1.0	incongruent_correct	1	2	incongruent	307	n/a
-33	102.5	1.0	incongruent_correct	1	2	incongruent	454	n/a
-34	105.0	1.0	congruent_incorrect	0	1	congruent	484	n/a
-35	107.5	1.0	congruent_correct	1	1	congruent	535	n/a
-36	110.0	1.0	incongruent_correct	1	2	incongruent	484	n/a
-37	112.5	1.0	incongruent_correct	1	2	incongruent	394	n/a
-38	120.0	1.0	incongruent_correct	1	2	incongruent	449	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	461	n/a
-40	125.0	1.0	congruent_correct	1	1	congruent	369	n/a
-41	127.5	1.0	congruent_correct	1	1	congruent	422	n/a
-42	135.0	1.0	incongruent_correct	1	2	incongruent	491	n/a
-43	137.5	1.0	congruent_correct	1	1	congruent	376	n/a
-44	140.0	1.0	congruent_correct	1	1	congruent	381	n/a
-45	142.5	1.0	incongruent_correct	1	2	incongruent	417	n/a
-46	145.0	1.0	congruent_correct	1	1	congruent	471	n/a
-47	147.5	1.0	incongruent_correct	1	2	incongruent	388	n/a
-48	150.0	1.0	congruent_incorrect	0	1	congruent	408	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	429	n/a
-50	155.0	1.0	congruent_correct	1	1	congruent	377	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	414	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	330	n/a
-53	162.5	1.0	congruent_correct	1	1	congruent	351	n/a
-54	170.0	1.0	incongruent_correct	1	2	incongruent	716	n/a
-55	172.5	1.0	congruent_correct	1	1	congruent	402	n/a
-56	175.0	1.0	congruent_correct	1	1	congruent	397	n/a
-57	177.5	1.0	incongruent_correct	1	2	incongruent	476	n/a
-58	185.0	1.0	incongruent_correct	1	2	incongruent	657	n/a
-59	187.5	1.0	incongruent_correct	1	2	incongruent	373	n/a
-60	190.0	1.0	incongruent_correct	1	2	incongruent	418	n/a
-61	192.5	1.0	incongruent_correct	1	2	incongruent	295	n/a
-62	195.0	1.0	congruent_correct	1	1	congruent	436	n/a
-63	197.5	1.0	congruent_correct	1	1	congruent	296	n/a
-64	200.0	1.0	congruent_correct	1	1	congruent	404	n/a
-65	202.5	1.0	incongruent_correct	1	2	incongruent	417	n/a
-66	205.0	1.0	incongruent_correct	1	2	incongruent	350	n/a
-67	207.5	1.0	incongruent_correct	1	2	incongruent	366	n/a
-68	215.0	1.0	incongruent_correct	1	2	incongruent	537	n/a
-69	217.5	1.0	incongruent_correct	1	2	incongruent	414	n/a
-70	220.0	1.0	congruent_correct	1	1	congruent	394	n/a
-71	222.5	1.0	incongruent_correct	1	2	incongruent	423	n/a
-72	225.0	1.0	incongruent_correct	1	2	incongruent	499	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	400	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	364	n/a
-75	232.5	1.0	congruent_correct	1	1	congruent	305	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	351	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	411	n/a
-78	240.0	1.0	incongruent_correct	1	2	incongruent	392	n/a
-79	242.5	1.0	congruent_correct	1	1	congruent	348	n/a
-80	245.0	1.0	congruent_correct	1	1	congruent	450	n/a
-81	247.5	1.0	incongruent_correct	1	2	incongruent	366	n/a
-82	250.0	1.0	congruent_incorrect	0	1	congruent	386	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	535	n/a
-84	255.0	1.0	incongruent_incorrect	0	2	incongruent	404	n/a
-85	257.5	1.0	congruent_correct	1	1	congruent	375	n/a
-86	270.0	1.0	incongruent_correct	1	2	incongruent	543	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	476	n/a
-88	275.0	1.0	congruent_correct	1	1	congruent	409	n/a
-89	277.5	1.0	incongruent_correct	1	2	incongruent	390	n/a
-90	280.0	1.0	incongruent_correct	1	2	incongruent	346	n/a
-91	282.5	1.0	congruent_correct	1	1	congruent	439	n/a
-92	290.0	1.0	congruent_incorrect	0	1	congruent	573	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	489	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	517	n/a
-95	297.5	1.0	congruent_correct	1	1	congruent	394	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	1	2	incongruent	440	n/a
+2.5	1.0	incongruent_correct	1	2	incongruent	413	n/a
+5.0	1.0	congruent_incorrect	0	1	congruent	417	n/a
+7.5	1.0	congruent_correct	1	1	congruent	374	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	371	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	382	n/a
+20.0	1.0	incongruent_correct	1	2	incongruent	478	n/a
+22.5	1.0	incongruent_correct	1	2	incongruent	345	n/a
+25.0	1.0	congruent_correct	1	1	congruent	448	n/a
+27.5	1.0	congruent_correct	1	1	congruent	323	n/a
+30.0	1.0	congruent_correct	1	1	congruent	440	n/a
+32.5	1.0	congruent_correct	1	1	congruent	300	n/a
+45.0	1.0	congruent_correct	1	1	congruent	420	n/a
+47.5	1.0	congruent_correct	1	1	congruent	298	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	421	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	305	n/a
+55.0	1.0	congruent_incorrect	0	1	congruent	399	n/a
+57.5	1.0	incongruent_correct	1	2	incongruent	533	n/a
+65.0	1.0	congruent_incorrect	0	1	congruent	553	n/a
+67.5	1.0	incongruent_correct	1	2	incongruent	398	n/a
+70.0	1.0	incongruent_correct	1	2	incongruent	442	n/a
+72.5	1.0	incongruent_correct	1	2	incongruent	415	n/a
+75.0	1.0	congruent_correct	1	1	congruent	484	n/a
+77.5	1.0	congruent_correct	1	1	congruent	400	n/a
+80.0	1.0	congruent_correct	1	1	congruent	509	n/a
+82.5	1.0	congruent_correct	1	1	congruent	363	n/a
+85.0	1.0	congruent_correct	1	1	congruent	383	n/a
+87.5	1.0	incongruent_correct	1	2	incongruent	707	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	441	n/a
+92.5	1.0	congruent_correct	1	1	congruent	476	n/a
+95.0	1.0	incongruent_correct	1	2	incongruent	345	n/a
+97.5	1.0	incongruent_correct	1	2	incongruent	374	n/a
+100.0	1.0	incongruent_correct	1	2	incongruent	307	n/a
+102.5	1.0	incongruent_correct	1	2	incongruent	454	n/a
+105.0	1.0	congruent_incorrect	0	1	congruent	484	n/a
+107.5	1.0	congruent_correct	1	1	congruent	535	n/a
+110.0	1.0	incongruent_correct	1	2	incongruent	484	n/a
+112.5	1.0	incongruent_correct	1	2	incongruent	394	n/a
+120.0	1.0	incongruent_correct	1	2	incongruent	449	n/a
+122.5	1.0	congruent_correct	1	1	congruent	461	n/a
+125.0	1.0	congruent_correct	1	1	congruent	369	n/a
+127.5	1.0	congruent_correct	1	1	congruent	422	n/a
+135.0	1.0	incongruent_correct	1	2	incongruent	491	n/a
+137.5	1.0	congruent_correct	1	1	congruent	376	n/a
+140.0	1.0	congruent_correct	1	1	congruent	381	n/a
+142.5	1.0	incongruent_correct	1	2	incongruent	417	n/a
+145.0	1.0	congruent_correct	1	1	congruent	471	n/a
+147.5	1.0	incongruent_correct	1	2	incongruent	388	n/a
+150.0	1.0	congruent_incorrect	0	1	congruent	408	n/a
+152.5	1.0	congruent_correct	1	1	congruent	429	n/a
+155.0	1.0	congruent_correct	1	1	congruent	377	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	414	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	330	n/a
+162.5	1.0	congruent_correct	1	1	congruent	351	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	716	n/a
+172.5	1.0	congruent_correct	1	1	congruent	402	n/a
+175.0	1.0	congruent_correct	1	1	congruent	397	n/a
+177.5	1.0	incongruent_correct	1	2	incongruent	476	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	657	n/a
+187.5	1.0	incongruent_correct	1	2	incongruent	373	n/a
+190.0	1.0	incongruent_correct	1	2	incongruent	418	n/a
+192.5	1.0	incongruent_correct	1	2	incongruent	295	n/a
+195.0	1.0	congruent_correct	1	1	congruent	436	n/a
+197.5	1.0	congruent_correct	1	1	congruent	296	n/a
+200.0	1.0	congruent_correct	1	1	congruent	404	n/a
+202.5	1.0	incongruent_correct	1	2	incongruent	417	n/a
+205.0	1.0	incongruent_correct	1	2	incongruent	350	n/a
+207.5	1.0	incongruent_correct	1	2	incongruent	366	n/a
+215.0	1.0	incongruent_correct	1	2	incongruent	537	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	414	n/a
+220.0	1.0	congruent_correct	1	1	congruent	394	n/a
+222.5	1.0	incongruent_correct	1	2	incongruent	423	n/a
+225.0	1.0	incongruent_correct	1	2	incongruent	499	n/a
+227.5	1.0	congruent_correct	1	1	congruent	400	n/a
+230.0	1.0	congruent_correct	1	1	congruent	364	n/a
+232.5	1.0	congruent_correct	1	1	congruent	305	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	351	n/a
+237.5	1.0	congruent_correct	1	1	congruent	411	n/a
+240.0	1.0	incongruent_correct	1	2	incongruent	392	n/a
+242.5	1.0	congruent_correct	1	1	congruent	348	n/a
+245.0	1.0	congruent_correct	1	1	congruent	450	n/a
+247.5	1.0	incongruent_correct	1	2	incongruent	366	n/a
+250.0	1.0	congruent_incorrect	0	1	congruent	386	n/a
+252.5	1.0	congruent_correct	1	1	congruent	535	n/a
+255.0	1.0	incongruent_incorrect	0	2	incongruent	404	n/a
+257.5	1.0	congruent_correct	1	1	congruent	375	n/a
+270.0	1.0	incongruent_correct	1	2	incongruent	543	n/a
+272.5	1.0	congruent_correct	1	1	congruent	476	n/a
+275.0	1.0	congruent_correct	1	1	congruent	409	n/a
+277.5	1.0	incongruent_correct	1	2	incongruent	390	n/a
+280.0	1.0	incongruent_correct	1	2	incongruent	346	n/a
+282.5	1.0	congruent_correct	1	1	congruent	439	n/a
+290.0	1.0	congruent_incorrect	0	1	congruent	573	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	489	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	517	n/a
+297.5	1.0	congruent_correct	1	1	congruent	394	n/a

--- a/ds101/sub-02/func/sub-02_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-02/func/sub-02_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	1	1	congruent	509	n/a
-1	2.5	1.0	congruent_correct	1	1	congruent	417	n/a
-2	10.0	1.0	incongruent_correct	1	2	incongruent	503	n/a
-3	12.5	1.0	incongruent_correct	1	2	incongruent	419	n/a
-4	15.0	1.0	incongruent_correct	1	2	incongruent	376	n/a
-5	17.5	1.0	incongruent_incorrect	0	2	incongruent	421	n/a
-6	25.0	1.0	congruent_correct	1	1	congruent	459	n/a
-7	27.5	1.0	congruent_correct	1	1	congruent	351	n/a
-8	30.0	1.0	incongruent_correct	1	2	incongruent	340	n/a
-9	32.5	1.0	congruent_correct	1	1	congruent	448	n/a
-10	35.0	1.0	incongruent_correct	1	2	incongruent	621	n/a
-11	37.5	1.0	congruent_correct	1	1	congruent	386	n/a
-12	40.0	1.0	congruent_correct	1	1	congruent	414	n/a
-13	42.5	1.0	incongruent_correct	1	2	incongruent	427	n/a
-14	45.0	1.0	incongruent_correct	1	2	incongruent	344	n/a
-15	47.5	1.0	incongruent_correct	1	2	incongruent	605	n/a
-16	50.0	1.0	incongruent_correct	1	2	incongruent	385	n/a
-17	52.5	1.0	incongruent_correct	1	2	incongruent	438	n/a
-18	60.0	1.0	congruent_incorrect	0	1	congruent	483	n/a
-19	62.5	1.0	congruent_correct	1	1	congruent	504	n/a
-20	65.0	1.0	congruent_correct	1	1	congruent	372	n/a
-21	67.5	1.0	congruent_correct	1	1	congruent	412	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	585	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	444	n/a
-24	80.0	1.0	congruent_correct	1	1	congruent	424	n/a
-25	82.5	1.0	incongruent_correct	1	2	incongruent	406	n/a
-26	85.0	1.0	incongruent_correct	1	2	incongruent	426	n/a
-27	87.5	1.0	congruent_correct	1	1	congruent	423	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	420	n/a
-29	92.5	1.0	congruent_correct	1	1	congruent	459	n/a
-30	95.0	1.0	congruent_correct	1	1	congruent	463	n/a
-31	97.5	1.0	incongruent_correct	1	2	incongruent	384	n/a
-32	100.0	1.0	congruent_correct	1	1	congruent	454	n/a
-33	102.5	1.0	incongruent_correct	1	2	incongruent	364	n/a
-34	105.0	1.0	incongruent_correct	1	2	incongruent	407	n/a
-35	107.5	1.0	incongruent_correct	1	2	incongruent	316	n/a
-36	110.0	1.0	congruent_correct	1	1	congruent	385	n/a
-37	112.5	1.0	congruent_correct	1	1	congruent	286	n/a
-38	120.0	1.0	congruent_correct	1	1	congruent	531	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	353	n/a
-40	125.0	1.0	congruent_correct	1	1	congruent	397	n/a
-41	127.5	1.0	congruent_correct	1	1	congruent	305	n/a
-42	130.0	1.0	congruent_correct	1	1	congruent	383	n/a
-43	132.5	1.0	incongruent_correct	1	2	incongruent	460	n/a
-44	135.0	1.0	congruent_correct	1	1	congruent	439	n/a
-45	137.5	1.0	incongruent_correct	1	2	incongruent	396	n/a
-46	140.0	1.0	congruent_correct	1	1	congruent	362	n/a
-47	142.5	1.0	incongruent_correct	1	2	incongruent	366	n/a
-48	150.0	1.0	incongruent_correct	1	2	incongruent	581	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	377	n/a
-50	155.0	1.0	incongruent_correct	1	2	incongruent	404	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	410	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	373	n/a
-53	162.5	1.0	incongruent_correct	1	2	incongruent	435	n/a
-54	165.0	1.0	incongruent_correct	1	2	incongruent	343	n/a
-55	167.5	1.0	incongruent_correct	1	2	incongruent	380	n/a
-56	170.0	1.0	incongruent_correct	1	2	incongruent	297	n/a
-57	172.5	1.0	incongruent_correct	1	2	incongruent	429	n/a
-58	175.0	1.0	congruent_incorrect	0	1	congruent	386	n/a
-59	177.5	1.0	congruent_correct	1	1	congruent	374	n/a
-60	185.0	1.0	incongruent_correct	1	2	incongruent	500	n/a
-61	187.5	1.0	congruent_correct	1	1	congruent	394	n/a
-62	190.0	1.0	congruent_correct	1	1	congruent	381	n/a
-63	192.5	1.0	incongruent_correct	1	2	incongruent	385	n/a
-64	195.0	1.0	incongruent_correct	1	2	incongruent	375	n/a
-65	197.5	1.0	incongruent_correct	1	2	incongruent	348	n/a
-66	200.0	1.0	incongruent_correct	1	2	incongruent	360	n/a
-67	202.5	1.0	congruent_correct	1	1	congruent	357	n/a
-68	210.0	1.0	incongruent_correct	1	2	incongruent	476	n/a
-69	212.5	1.0	incongruent_correct	1	2	incongruent	336	n/a
-70	215.0	1.0	congruent_incorrect	0	1	congruent	420	n/a
-71	217.5	1.0	incongruent_correct	1	2	incongruent	393	n/a
-72	225.0	1.0	congruent_correct	1	1	congruent	734	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	316	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	408	n/a
-75	232.5	1.0	congruent_correct	1	1	congruent	398	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	618	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	502	n/a
-78	240.0	1.0	congruent_correct	1	1	congruent	543	n/a
-79	242.5	1.0	incongruent_correct	1	2	incongruent	551	n/a
-80	245.0	1.0	incongruent_correct	1	2	incongruent	476	n/a
-81	247.5	1.0	congruent_correct	1	1	congruent	473	n/a
-82	250.0	1.0	incongruent_correct	1	2	incongruent	429	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	497	n/a
-84	260.0	1.0	incongruent_correct	1	2	incongruent	488	n/a
-85	262.5	1.0	congruent_correct	1	1	congruent	542	n/a
-86	270.0	1.0	congruent_correct	1	1	congruent	634	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	351	n/a
-88	275.0	1.0	incongruent_correct	1	2	incongruent	516	n/a
-89	277.5	1.0	congruent_correct	1	1	congruent	488	n/a
-90	285.0	1.0	congruent_correct	1	1	congruent	526	n/a
-91	287.5	1.0	incongruent_correct	1	2	incongruent	379	n/a
-92	290.0	1.0	congruent_correct	1	1	congruent	447	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	500	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	439	n/a
-95	297.5	1.0	incongruent_correct	1	2	incongruent	544	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	1	1	congruent	509	n/a
+2.5	1.0	congruent_correct	1	1	congruent	417	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	503	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	419	n/a
+15.0	1.0	incongruent_correct	1	2	incongruent	376	n/a
+17.5	1.0	incongruent_incorrect	0	2	incongruent	421	n/a
+25.0	1.0	congruent_correct	1	1	congruent	459	n/a
+27.5	1.0	congruent_correct	1	1	congruent	351	n/a
+30.0	1.0	incongruent_correct	1	2	incongruent	340	n/a
+32.5	1.0	congruent_correct	1	1	congruent	448	n/a
+35.0	1.0	incongruent_correct	1	2	incongruent	621	n/a
+37.5	1.0	congruent_correct	1	1	congruent	386	n/a
+40.0	1.0	congruent_correct	1	1	congruent	414	n/a
+42.5	1.0	incongruent_correct	1	2	incongruent	427	n/a
+45.0	1.0	incongruent_correct	1	2	incongruent	344	n/a
+47.5	1.0	incongruent_correct	1	2	incongruent	605	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	385	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	438	n/a
+60.0	1.0	congruent_incorrect	0	1	congruent	483	n/a
+62.5	1.0	congruent_correct	1	1	congruent	504	n/a
+65.0	1.0	congruent_correct	1	1	congruent	372	n/a
+67.5	1.0	congruent_correct	1	1	congruent	412	n/a
+75.0	1.0	congruent_correct	1	1	congruent	585	n/a
+77.5	1.0	congruent_correct	1	1	congruent	444	n/a
+80.0	1.0	congruent_correct	1	1	congruent	424	n/a
+82.5	1.0	incongruent_correct	1	2	incongruent	406	n/a
+85.0	1.0	incongruent_correct	1	2	incongruent	426	n/a
+87.5	1.0	congruent_correct	1	1	congruent	423	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	420	n/a
+92.5	1.0	congruent_correct	1	1	congruent	459	n/a
+95.0	1.0	congruent_correct	1	1	congruent	463	n/a
+97.5	1.0	incongruent_correct	1	2	incongruent	384	n/a
+100.0	1.0	congruent_correct	1	1	congruent	454	n/a
+102.5	1.0	incongruent_correct	1	2	incongruent	364	n/a
+105.0	1.0	incongruent_correct	1	2	incongruent	407	n/a
+107.5	1.0	incongruent_correct	1	2	incongruent	316	n/a
+110.0	1.0	congruent_correct	1	1	congruent	385	n/a
+112.5	1.0	congruent_correct	1	1	congruent	286	n/a
+120.0	1.0	congruent_correct	1	1	congruent	531	n/a
+122.5	1.0	congruent_correct	1	1	congruent	353	n/a
+125.0	1.0	congruent_correct	1	1	congruent	397	n/a
+127.5	1.0	congruent_correct	1	1	congruent	305	n/a
+130.0	1.0	congruent_correct	1	1	congruent	383	n/a
+132.5	1.0	incongruent_correct	1	2	incongruent	460	n/a
+135.0	1.0	congruent_correct	1	1	congruent	439	n/a
+137.5	1.0	incongruent_correct	1	2	incongruent	396	n/a
+140.0	1.0	congruent_correct	1	1	congruent	362	n/a
+142.5	1.0	incongruent_correct	1	2	incongruent	366	n/a
+150.0	1.0	incongruent_correct	1	2	incongruent	581	n/a
+152.5	1.0	congruent_correct	1	1	congruent	377	n/a
+155.0	1.0	incongruent_correct	1	2	incongruent	404	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	410	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	373	n/a
+162.5	1.0	incongruent_correct	1	2	incongruent	435	n/a
+165.0	1.0	incongruent_correct	1	2	incongruent	343	n/a
+167.5	1.0	incongruent_correct	1	2	incongruent	380	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	297	n/a
+172.5	1.0	incongruent_correct	1	2	incongruent	429	n/a
+175.0	1.0	congruent_incorrect	0	1	congruent	386	n/a
+177.5	1.0	congruent_correct	1	1	congruent	374	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	500	n/a
+187.5	1.0	congruent_correct	1	1	congruent	394	n/a
+190.0	1.0	congruent_correct	1	1	congruent	381	n/a
+192.5	1.0	incongruent_correct	1	2	incongruent	385	n/a
+195.0	1.0	incongruent_correct	1	2	incongruent	375	n/a
+197.5	1.0	incongruent_correct	1	2	incongruent	348	n/a
+200.0	1.0	incongruent_correct	1	2	incongruent	360	n/a
+202.5	1.0	congruent_correct	1	1	congruent	357	n/a
+210.0	1.0	incongruent_correct	1	2	incongruent	476	n/a
+212.5	1.0	incongruent_correct	1	2	incongruent	336	n/a
+215.0	1.0	congruent_incorrect	0	1	congruent	420	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	393	n/a
+225.0	1.0	congruent_correct	1	1	congruent	734	n/a
+227.5	1.0	congruent_correct	1	1	congruent	316	n/a
+230.0	1.0	congruent_correct	1	1	congruent	408	n/a
+232.5	1.0	congruent_correct	1	1	congruent	398	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	618	n/a
+237.5	1.0	congruent_correct	1	1	congruent	502	n/a
+240.0	1.0	congruent_correct	1	1	congruent	543	n/a
+242.5	1.0	incongruent_correct	1	2	incongruent	551	n/a
+245.0	1.0	incongruent_correct	1	2	incongruent	476	n/a
+247.5	1.0	congruent_correct	1	1	congruent	473	n/a
+250.0	1.0	incongruent_correct	1	2	incongruent	429	n/a
+252.5	1.0	congruent_correct	1	1	congruent	497	n/a
+260.0	1.0	incongruent_correct	1	2	incongruent	488	n/a
+262.5	1.0	congruent_correct	1	1	congruent	542	n/a
+270.0	1.0	congruent_correct	1	1	congruent	634	n/a
+272.5	1.0	congruent_correct	1	1	congruent	351	n/a
+275.0	1.0	incongruent_correct	1	2	incongruent	516	n/a
+277.5	1.0	congruent_correct	1	1	congruent	488	n/a
+285.0	1.0	congruent_correct	1	1	congruent	526	n/a
+287.5	1.0	incongruent_correct	1	2	incongruent	379	n/a
+290.0	1.0	congruent_correct	1	1	congruent	447	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	500	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	439	n/a
+297.5	1.0	incongruent_correct	1	2	incongruent	544	n/a

--- a/ds101/sub-03/func/sub-03_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-03/func/sub-03_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	451	n/a
-2	5.0	1.0	congruent_incorrect	n/a	0	1	congruent	464	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	452	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	494	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	662	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	409	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	651	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	617	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	780	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	641	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	720	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	594	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	469	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	618	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	470	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	402	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	496	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	469	n/a
-27	87.5	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	615	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	579	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	476	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	416	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	508	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	425	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	519	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	579	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	400	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	531	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	412	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	543	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	572	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	360	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	612	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	676	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	601	n/a
-58	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	548	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	518	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	674	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	447	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	547	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	552	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	476	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	613	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	485	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	593	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	558	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	483	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	319	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	501	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	537	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	389	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	471	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	498	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	494	n/a
-86	270.0	1.0	incongruent_correct	n/a	1	2	incongruent	565	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	450	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
-89	277.5	1.0	incongruent_correct	n/a	1	2	incongruent	522	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	446	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	499	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	415	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	452	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	521	n/a
+onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	451	n/a
+5.0	1.0	congruent_incorrect	n/a	0	1	congruent	464	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	452	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	494	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	662	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	409	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	651	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	617	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	780	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	641	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	720	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	594	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	469	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	618	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	470	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	402	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	496	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	469	n/a
+87.5	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	615	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	579	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	476	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	416	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	508	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	425	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	519	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	579	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	400	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	531	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	412	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	543	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	572	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	360	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	612	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	676	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	601	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	548	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	518	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	674	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	447	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	547	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	552	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	476	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	613	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	485	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	593	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	558	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	483	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	319	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	501	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	537	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	389	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	471	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	498	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	494	n/a
+270.0	1.0	incongruent_correct	n/a	1	2	incongruent	565	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	450	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
+277.5	1.0	incongruent_correct	n/a	1	2	incongruent	522	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	446	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	499	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	415	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	452	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	521	n/a

--- a/ds101/sub-03/func/sub-03_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-03/func/sub-03_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	497	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	350	n/a
-2	10.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	523	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	454	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	541	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	475	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	734	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	742	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	577	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	457	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	492	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	440	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	506	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	520	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	500	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	370	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	365	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	385	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
-25	82.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	417	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	596	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	541	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	588	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	584	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	609	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	422	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	562	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	544	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	509	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	681	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	530	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	663	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	488	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	632	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	454	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	571	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	430	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	588	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	526	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	450	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	543	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	491	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	488	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	455	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	355	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	529	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	485	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	554	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	553	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	445	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	514	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	598	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	395	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	613	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	669	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	344	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	546	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
-91	287.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	402	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	398	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	497	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	350	n/a
+10.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	523	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	454	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	541	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	475	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	734	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	742	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	577	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	457	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	492	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	440	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	506	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	520	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	500	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	370	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	365	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	385	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
+82.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	417	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	596	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	541	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	588	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	584	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	609	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	422	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	562	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	544	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	509	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	681	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	530	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	663	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	488	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	632	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	454	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	571	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	430	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	588	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	526	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	450	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	543	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	491	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	488	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	455	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	355	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	529	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	485	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	554	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	553	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	445	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	514	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	598	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	395	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	613	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	669	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	344	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	546	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
+287.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	402	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	398	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a

--- a/ds101/sub-04/func/sub-04_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-04/func/sub-04_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	1	2	incongruent	509	n/a
-1	2.5	1.0	incongruent_correct	1	2	incongruent	512	n/a
-2	5.0	1.0	congruent_correct	1	1	congruent	517	n/a
-3	7.5	1.0	congruent_correct	1	1	congruent	472	n/a
-4	10.0	1.0	incongruent_correct	1	2	incongruent	614	n/a
-5	12.5	1.0	incongruent_correct	1	2	incongruent	507	n/a
-6	20.0	1.0	incongruent_correct	1	2	incongruent	544	n/a
-7	22.5	1.0	incongruent_correct	1	2	incongruent	431	n/a
-8	25.0	1.0	congruent_correct	1	1	congruent	467	n/a
-9	27.5	1.0	congruent_correct	1	1	congruent	446	n/a
-10	30.0	1.0	congruent_correct	1	1	congruent	492	n/a
-11	32.5	1.0	congruent_correct	1	1	congruent	424	n/a
-12	45.0	1.0	congruent_correct	1	1	congruent	615	n/a
-13	47.5	1.0	congruent_correct	1	1	congruent	372	n/a
-14	50.0	1.0	incongruent_correct	1	2	incongruent	601	n/a
-15	52.5	1.0	incongruent_correct	1	2	incongruent	573	n/a
-16	55.0	1.0	congruent_correct	1	1	congruent	522	n/a
-17	57.5	1.0	incongruent_correct	1	2	incongruent	592	n/a
-18	65.0	1.0	congruent_correct	1	1	congruent	750	n/a
-19	67.5	1.0	incongruent_incorrect	0	2	incongruent	682	n/a
-20	70.0	1.0	incongruent_correct	1	2	incongruent	534	n/a
-21	72.5	1.0	incongruent_correct	1	2	incongruent	524	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	575	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	429	n/a
-24	80.0	1.0	congruent_correct	1	1	congruent	424	n/a
-25	82.5	1.0	congruent_correct	1	1	congruent	477	n/a
-26	85.0	1.0	congruent_correct	1	1	congruent	386	n/a
-27	87.5	1.0	incongruent_correct	1	2	incongruent	503	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	596	n/a
-29	92.5	1.0	congruent_correct	1	1	congruent	473	n/a
-30	95.0	1.0	incongruent_correct	1	2	incongruent	525	n/a
-31	97.5	1.0	incongruent_correct	1	2	incongruent	545	n/a
-32	100.0	1.0	incongruent_correct	1	2	incongruent	454	n/a
-33	102.5	1.0	incongruent_correct	1	2	incongruent	475	n/a
-34	105.0	1.0	congruent_correct	1	1	congruent	496	n/a
-35	107.5	1.0	congruent_correct	1	1	congruent	541	n/a
-36	110.0	1.0	incongruent_correct	1	2	incongruent	545	n/a
-37	112.5	1.0	incongruent_correct	1	2	incongruent	533	n/a
-38	120.0	1.0	incongruent_correct	1	2	incongruent	619	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	536	n/a
-40	125.0	1.0	congruent_correct	1	1	congruent	438	n/a
-41	127.5	1.0	congruent_correct	1	1	congruent	474	n/a
-42	135.0	1.0	incongruent_correct	1	2	incongruent	551	n/a
-43	137.5	1.0	congruent_correct	1	1	congruent	533	n/a
-44	140.0	1.0	congruent_correct	1	1	congruent	440	n/a
-45	142.5	1.0	incongruent_correct	1	2	incongruent	509	n/a
-46	145.0	1.0	congruent_incorrect	0	1	congruent	603	n/a
-47	147.5	1.0	incongruent_correct	1	2	incongruent	678	n/a
-48	150.0	1.0	congruent_correct	1	1	congruent	514	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	432	n/a
-50	155.0	1.0	congruent_correct	1	1	congruent	470	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	537	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	494	n/a
-53	162.5	1.0	congruent_correct	1	1	congruent	595	n/a
-54	170.0	1.0	incongruent_correct	1	2	incongruent	600	n/a
-55	172.5	1.0	congruent_correct	1	1	congruent	645	n/a
-56	175.0	1.0	congruent_correct	1	1	congruent	457	n/a
-57	177.5	1.0	incongruent_correct	1	2	incongruent	503	n/a
-58	185.0	1.0	incongruent_correct	1	2	incongruent	559	n/a
-59	187.5	1.0	incongruent_correct	1	2	incongruent	530	n/a
-60	190.0	1.0	incongruent_correct	1	2	incongruent	414	n/a
-61	192.5	1.0	incongruent_correct	1	2	incongruent	475	n/a
-62	195.0	1.0	congruent_correct	1	1	congruent	448	n/a
-63	197.5	1.0	congruent_correct	1	1	congruent	475	n/a
-64	200.0	1.0	congruent_correct	1	1	congruent	465	n/a
-65	202.5	1.0	incongruent_correct	1	2	incongruent	478	n/a
-66	205.0	1.0	incongruent_correct	1	2	incongruent	457	n/a
-67	207.5	1.0	incongruent_correct	1	2	incongruent	623	n/a
-68	215.0	1.0	incongruent_correct	1	2	incongruent	507	n/a
-69	217.5	1.0	incongruent_correct	1	2	incongruent	425	n/a
-70	220.0	1.0	congruent_correct	1	1	congruent	470	n/a
-71	222.5	1.0	incongruent_correct	1	2	incongruent	509	n/a
-72	225.0	1.0	incongruent_correct	1	2	incongruent	439	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	428	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	505	n/a
-75	232.5	1.0	congruent_correct	1	1	congruent	477	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	585	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	582	n/a
-78	240.0	1.0	incongruent_correct	1	2	incongruent	516	n/a
-79	242.5	1.0	congruent_correct	1	1	congruent	463	n/a
-80	245.0	1.0	congruent_correct	1	1	congruent	477	n/a
-81	247.5	1.0	incongruent_correct	1	2	incongruent	689	n/a
-82	250.0	1.0	congruent_correct	1	1	congruent	447	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	530	n/a
-84	255.0	1.0	incongruent_correct	1	2	incongruent	607	n/a
-85	257.5	1.0	congruent_correct	1	1	congruent	492	n/a
-86	270.0	1.0	incongruent_correct	1	2	incongruent	547	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	424	n/a
-88	275.0	1.0	congruent_correct	1	1	congruent	405	n/a
-89	277.5	1.0	incongruent_correct	1	2	incongruent	504	n/a
-90	280.0	1.0	incongruent_correct	1	2	incongruent	501	n/a
-91	282.5	1.0	congruent_correct	1	1	congruent	580	n/a
-92	290.0	1.0	congruent_correct	1	1	congruent	497	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	477	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	490	n/a
-95	297.5	1.0	congruent_correct	1	1	congruent	454	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	1	2	incongruent	509	n/a
+2.5	1.0	incongruent_correct	1	2	incongruent	512	n/a
+5.0	1.0	congruent_correct	1	1	congruent	517	n/a
+7.5	1.0	congruent_correct	1	1	congruent	472	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	614	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	507	n/a
+20.0	1.0	incongruent_correct	1	2	incongruent	544	n/a
+22.5	1.0	incongruent_correct	1	2	incongruent	431	n/a
+25.0	1.0	congruent_correct	1	1	congruent	467	n/a
+27.5	1.0	congruent_correct	1	1	congruent	446	n/a
+30.0	1.0	congruent_correct	1	1	congruent	492	n/a
+32.5	1.0	congruent_correct	1	1	congruent	424	n/a
+45.0	1.0	congruent_correct	1	1	congruent	615	n/a
+47.5	1.0	congruent_correct	1	1	congruent	372	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	601	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	573	n/a
+55.0	1.0	congruent_correct	1	1	congruent	522	n/a
+57.5	1.0	incongruent_correct	1	2	incongruent	592	n/a
+65.0	1.0	congruent_correct	1	1	congruent	750	n/a
+67.5	1.0	incongruent_incorrect	0	2	incongruent	682	n/a
+70.0	1.0	incongruent_correct	1	2	incongruent	534	n/a
+72.5	1.0	incongruent_correct	1	2	incongruent	524	n/a
+75.0	1.0	congruent_correct	1	1	congruent	575	n/a
+77.5	1.0	congruent_correct	1	1	congruent	429	n/a
+80.0	1.0	congruent_correct	1	1	congruent	424	n/a
+82.5	1.0	congruent_correct	1	1	congruent	477	n/a
+85.0	1.0	congruent_correct	1	1	congruent	386	n/a
+87.5	1.0	incongruent_correct	1	2	incongruent	503	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	596	n/a
+92.5	1.0	congruent_correct	1	1	congruent	473	n/a
+95.0	1.0	incongruent_correct	1	2	incongruent	525	n/a
+97.5	1.0	incongruent_correct	1	2	incongruent	545	n/a
+100.0	1.0	incongruent_correct	1	2	incongruent	454	n/a
+102.5	1.0	incongruent_correct	1	2	incongruent	475	n/a
+105.0	1.0	congruent_correct	1	1	congruent	496	n/a
+107.5	1.0	congruent_correct	1	1	congruent	541	n/a
+110.0	1.0	incongruent_correct	1	2	incongruent	545	n/a
+112.5	1.0	incongruent_correct	1	2	incongruent	533	n/a
+120.0	1.0	incongruent_correct	1	2	incongruent	619	n/a
+122.5	1.0	congruent_correct	1	1	congruent	536	n/a
+125.0	1.0	congruent_correct	1	1	congruent	438	n/a
+127.5	1.0	congruent_correct	1	1	congruent	474	n/a
+135.0	1.0	incongruent_correct	1	2	incongruent	551	n/a
+137.5	1.0	congruent_correct	1	1	congruent	533	n/a
+140.0	1.0	congruent_correct	1	1	congruent	440	n/a
+142.5	1.0	incongruent_correct	1	2	incongruent	509	n/a
+145.0	1.0	congruent_incorrect	0	1	congruent	603	n/a
+147.5	1.0	incongruent_correct	1	2	incongruent	678	n/a
+150.0	1.0	congruent_correct	1	1	congruent	514	n/a
+152.5	1.0	congruent_correct	1	1	congruent	432	n/a
+155.0	1.0	congruent_correct	1	1	congruent	470	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	537	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	494	n/a
+162.5	1.0	congruent_correct	1	1	congruent	595	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	600	n/a
+172.5	1.0	congruent_correct	1	1	congruent	645	n/a
+175.0	1.0	congruent_correct	1	1	congruent	457	n/a
+177.5	1.0	incongruent_correct	1	2	incongruent	503	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	559	n/a
+187.5	1.0	incongruent_correct	1	2	incongruent	530	n/a
+190.0	1.0	incongruent_correct	1	2	incongruent	414	n/a
+192.5	1.0	incongruent_correct	1	2	incongruent	475	n/a
+195.0	1.0	congruent_correct	1	1	congruent	448	n/a
+197.5	1.0	congruent_correct	1	1	congruent	475	n/a
+200.0	1.0	congruent_correct	1	1	congruent	465	n/a
+202.5	1.0	incongruent_correct	1	2	incongruent	478	n/a
+205.0	1.0	incongruent_correct	1	2	incongruent	457	n/a
+207.5	1.0	incongruent_correct	1	2	incongruent	623	n/a
+215.0	1.0	incongruent_correct	1	2	incongruent	507	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	425	n/a
+220.0	1.0	congruent_correct	1	1	congruent	470	n/a
+222.5	1.0	incongruent_correct	1	2	incongruent	509	n/a
+225.0	1.0	incongruent_correct	1	2	incongruent	439	n/a
+227.5	1.0	congruent_correct	1	1	congruent	428	n/a
+230.0	1.0	congruent_correct	1	1	congruent	505	n/a
+232.5	1.0	congruent_correct	1	1	congruent	477	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	585	n/a
+237.5	1.0	congruent_correct	1	1	congruent	582	n/a
+240.0	1.0	incongruent_correct	1	2	incongruent	516	n/a
+242.5	1.0	congruent_correct	1	1	congruent	463	n/a
+245.0	1.0	congruent_correct	1	1	congruent	477	n/a
+247.5	1.0	incongruent_correct	1	2	incongruent	689	n/a
+250.0	1.0	congruent_correct	1	1	congruent	447	n/a
+252.5	1.0	congruent_correct	1	1	congruent	530	n/a
+255.0	1.0	incongruent_correct	1	2	incongruent	607	n/a
+257.5	1.0	congruent_correct	1	1	congruent	492	n/a
+270.0	1.0	incongruent_correct	1	2	incongruent	547	n/a
+272.5	1.0	congruent_correct	1	1	congruent	424	n/a
+275.0	1.0	congruent_correct	1	1	congruent	405	n/a
+277.5	1.0	incongruent_correct	1	2	incongruent	504	n/a
+280.0	1.0	incongruent_correct	1	2	incongruent	501	n/a
+282.5	1.0	congruent_correct	1	1	congruent	580	n/a
+290.0	1.0	congruent_correct	1	1	congruent	497	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	477	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	490	n/a
+297.5	1.0	congruent_correct	1	1	congruent	454	n/a

--- a/ds101/sub-04/func/sub-04_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-04/func/sub-04_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	478	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	486	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	373	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-8	30.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	366	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	547	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	632	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	403	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	448	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	604	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	511	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	442	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	351	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	356	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	518	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	476	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	517	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	548	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	504	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	417	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	491	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	470	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	371	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	448	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	428	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	473	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	541	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	426	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	412	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	536	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	450	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	612	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	424	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	417	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	427	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	518	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	418	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	501	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	484	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	430	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	402	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	375	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	469	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	617	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	527	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	490	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	492	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	609	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	484	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
-84	260.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	475	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	519	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	678	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	482	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	551	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	478	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	486	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	373	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+30.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	366	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	547	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	632	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	403	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	448	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	604	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	511	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	442	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	351	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	356	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	518	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	476	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	517	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	548	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	504	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	417	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	491	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	470	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	371	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	448	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	428	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	473	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	541	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	426	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	412	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	536	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	450	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	612	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	424	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	417	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	427	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	518	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	418	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	501	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	484	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	430	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	402	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	375	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	469	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	617	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	527	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	490	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	492	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	609	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	484	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
+260.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	475	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	519	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	678	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	482	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	551	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a

--- a/ds101/sub-05/func/sub-05_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-05/func/sub-05_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	1	2	incongruent	617	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	373	n/a
-2	5.0	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	351	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	424	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	542	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	355	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	359	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	323	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	336	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	264	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	573	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	433	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	372	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	706	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	366	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	379	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	320	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	329	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	471	n/a
-27	87.5	1.0	incongruent_correct	n/a	1	2	incongruent	467	n/a
-28	90.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	465	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	452	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	335	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	385	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	551	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	345	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	564	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	332	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	395	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	440	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	613	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	374	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	419	n/a
-58	185.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	393	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	389	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	370	n/a
-61	192.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	375	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	409	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	555	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	434	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	493	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	403	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	455	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	436	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	299	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	383	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	481	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	516	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	288	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	461	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	378	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	415	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	368	n/a
-86	270.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	455	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	588	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	593	n/a
-89	277.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	389	n/a
-90	280.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	393	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	734	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	628	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	569	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	461	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	1	2	incongruent	617	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	373	n/a
+5.0	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	351	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	424	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	542	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	355	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	359	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	323	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	336	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	264	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	573	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	433	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	372	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	706	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	366	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	379	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	320	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	329	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	471	n/a
+87.5	1.0	incongruent_correct	n/a	1	2	incongruent	467	n/a
+90.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	465	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	452	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	335	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	385	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	551	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	345	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	564	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	332	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	395	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	440	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	613	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	374	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	419	n/a
+185.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	393	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	389	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	370	n/a
+192.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	375	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	409	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	555	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	434	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	493	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	403	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	455	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	436	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	299	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	383	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	481	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	516	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	288	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	461	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	378	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	415	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	368	n/a
+270.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	455	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	588	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	593	n/a
+277.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	389	n/a
+280.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	393	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	734	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	628	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	569	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	461	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	354	n/a

--- a/ds101/sub-05/func/sub-05_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-05/func/sub-05_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	410	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	461	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	423	n/a
-6	25.0	1.0	congruent_incorrect	n/a	0	1	congruent	461	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	827	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	566	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	418	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	432	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	582	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	607	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	574	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	543	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	491	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	529	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	402	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	399	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	523	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	424	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	455	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	352	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	518	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	331	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	323	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	606	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	399	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	613	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	511	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	568	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	388	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	427	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	334	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	388	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	440	n/a
-58	175.0	1.0	congruent_incorrect	n/a	0	1	congruent	484	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	418	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	470	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	457	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	404	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	352	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	533	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	425	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	512	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	317	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	376	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	576	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	438	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	434	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	383	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	440	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	404	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	456	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	452	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	585	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	440	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	404	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
+onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	410	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	461	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	423	n/a
+25.0	1.0	congruent_incorrect	n/a	0	1	congruent	461	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	827	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	566	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	418	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	432	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	582	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	607	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	574	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	543	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	491	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	529	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	402	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	399	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	523	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	424	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	455	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	352	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	518	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	331	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	323	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	606	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	399	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	613	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	511	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	568	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	388	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	427	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	334	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	388	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	440	n/a
+175.0	1.0	congruent_incorrect	n/a	0	1	congruent	484	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	418	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	470	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	457	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	404	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	352	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	533	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	425	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	512	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	317	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	376	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	576	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	438	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	434	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	383	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	440	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	404	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	456	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	452	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	585	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	440	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	404	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a

--- a/ds101/sub-06/func/sub-06_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-06/func/sub-06_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	1	2	incongruent	625	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	453	n/a
-2	5.0	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	511	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	376	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	965	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	370	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	342	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	493	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	573	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	487	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	490	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	327	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	437	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	345	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	340	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	314	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
-27	87.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	405	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	458	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	358	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	323	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	338	n/a
-36	110.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	415	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	632	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	369	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	391	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	580	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	401	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	446	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	563	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	383	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	324	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	475	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	490	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	470	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	451	n/a
-58	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	769	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	581	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	400	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	620	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	332	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	326	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	486	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	452	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	455	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	361	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	442	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	543	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	571	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	529	n/a
-86	270.0	1.0	incongruent_correct	n/a	1	2	incongruent	607	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	377	n/a
-89	277.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	390	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	554	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	550	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	614	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	506	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	1	2	incongruent	625	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	453	n/a
+5.0	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	511	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	376	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	965	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	370	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	342	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	493	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	573	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	487	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	490	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	327	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	437	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	345	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	340	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	314	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
+87.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	405	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	458	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	358	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	323	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	338	n/a
+110.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	415	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	632	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	369	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	391	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	580	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	401	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	446	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	563	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	383	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	324	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	475	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	490	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	470	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	451	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	769	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	581	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	400	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	620	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	332	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	326	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	486	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	452	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	455	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	361	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	442	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	543	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	571	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	529	n/a
+270.0	1.0	incongruent_correct	n/a	1	2	incongruent	607	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	377	n/a
+277.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	390	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	554	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	550	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	614	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	506	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	387	n/a

--- a/ds101/sub-06/func/sub-06_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-06/func/sub-06_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	827	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	579	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	644	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	433	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	624	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	409	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	430	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	367	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	371	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	440	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	308	n/a
-15	47.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	377	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	584	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	422	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	382	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	531	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	377	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	425	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	423	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	348	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	401	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	494	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	432	n/a
-34	105.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	389	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	544	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	359	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	496	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	490	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	439	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	553	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	494	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	378	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	576	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	521	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
-52	160.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	371	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	432	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	394	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	658	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	574	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	580	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	424	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	445	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	426	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	397	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	377	n/a
-76	235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	342	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	363	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	410	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	567	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	459	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	553	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	526	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	381	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	450	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	364	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	827	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	579	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	644	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	433	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	624	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	409	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	430	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	367	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	371	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	440	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	308	n/a
+47.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	377	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	584	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	422	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	382	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	531	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	377	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	425	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	423	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	348	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	401	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	494	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	432	n/a
+105.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	389	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	544	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	359	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	496	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	490	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	439	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	553	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	494	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	378	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	576	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	521	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
+160.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	371	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	432	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	394	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	658	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	574	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	580	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	424	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	445	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	426	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	397	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	377	n/a
+235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	342	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	363	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	410	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	567	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	459	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	553	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	526	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	381	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	450	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	364	n/a

--- a/ds101/sub-07/func/sub-07_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-07/func/sub-07_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	1	2	incongruent	586	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
-2	5.0	1.0	congruent_incorrect	n/a	0	1	congruent	801	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	454	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	436	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	369	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	395	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	482	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	376	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	603	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
-16	55.0	1.0	congruent_incorrect	n/a	0	1	congruent	556	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	682	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	1049	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	463	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	475	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	480	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	532	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	521	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
-27	87.5	1.0	incongruent_correct	n/a	1	2	incongruent	659	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	443	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	568	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	509	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	714	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	573	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	496	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	520	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	622	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	507	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	488	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	496	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	477	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	478	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	539	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	559	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	565	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	470	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	669	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	518	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
-58	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	560	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	508	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	445	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	675	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	484	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	475	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	533	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	583	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	476	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	713	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	590	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	442	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	525	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	534	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	630	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	443	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	432	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	690	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
-86	270.0	1.0	incongruent_correct	n/a	1	2	incongruent	630	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	444	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	439	n/a
-89	277.5	1.0	incongruent_correct	n/a	1	2	incongruent	517	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	437	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	568	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	486	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	561	n/a
+onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	1	2	incongruent	586	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
+5.0	1.0	congruent_incorrect	n/a	0	1	congruent	801	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	454	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	436	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	369	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	395	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	482	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	376	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	603	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
+55.0	1.0	congruent_incorrect	n/a	0	1	congruent	556	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	682	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	1049	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	463	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	475	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	480	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	532	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	521	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
+87.5	1.0	incongruent_correct	n/a	1	2	incongruent	659	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	443	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	568	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	509	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	714	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	573	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	496	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	520	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	622	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	507	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	488	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	496	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	477	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	478	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	539	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	559	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	565	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	470	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	669	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	518	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	560	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	508	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	445	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	675	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	484	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	475	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	533	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	583	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	476	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	713	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	590	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	442	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	525	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	534	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	630	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	443	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	432	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	690	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
+270.0	1.0	incongruent_correct	n/a	1	2	incongruent	630	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	444	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	439	n/a
+277.5	1.0	incongruent_correct	n/a	1	2	incongruent	517	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	437	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	568	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	486	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	561	n/a

--- a/ds101/sub-07/func/sub-07_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-07/func/sub-07_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	450	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	439	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	572	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	518	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	402	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	609	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	515	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	574	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	415	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	485	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	747	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	570	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	395	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	542	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	619	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	484	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	521	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	514	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	439	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	443	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	520	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	416	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	499	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	631	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	432	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	505	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	494	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	371	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	475	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	552	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	534	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	402	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	527	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	425	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
-58	175.0	1.0	congruent_incorrect	n/a	0	1	congruent	540	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	696	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	711	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	519	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	476	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	470	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	441	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	638	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	498	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	450	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	913	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	482	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	446	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	493	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	459	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	553	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	594	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	645	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	553	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	564	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	709	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	729	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	608	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	550	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	626	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	458	n/a
+onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	450	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	439	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	572	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	518	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	402	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	609	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	515	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	574	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	415	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	485	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	747	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	570	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	395	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	542	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	619	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	484	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	521	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	514	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	439	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	443	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	520	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	416	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	499	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	631	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	432	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	505	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	494	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	371	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	475	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	552	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	534	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	402	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	527	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	425	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
+175.0	1.0	congruent_incorrect	n/a	0	1	congruent	540	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	696	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	711	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	519	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	476	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	470	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	441	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	638	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	498	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	450	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	913	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	482	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	446	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	493	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	459	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	553	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	594	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	645	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	553	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	564	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	709	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	729	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	608	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	550	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	626	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	458	n/a

--- a/ds101/sub-08/func/sub-08_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-08/func/sub-08_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	793	n/a
-1	2.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	542	n/a
-2	5.0	1.0	congruent_correct	n/a	1	1	congruent	931	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	966	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	764	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	713	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	662	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	784	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	649	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	693	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	1021	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	767	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	667	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	682	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	780	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	571	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	679	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	995	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	577	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	878	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	513	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	663	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	566	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	758	n/a
-27	87.5	1.0	incongruent_correct	n/a	1	2	incongruent	875	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	737	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	654	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	643	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	1150	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	620	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	424	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	516	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	679	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	867	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	1081	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	694	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	715	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	784	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	685	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	585	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	630	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	620	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	761	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	581	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	570	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	564	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	562	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	752	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	596	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	847	n/a
-54	170.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	0	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	770	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	576	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
-58	185.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	546	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	616	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	675	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	695	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	749	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	634	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	814	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	816	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	687	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	653	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	914	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	654	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	700	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	744	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	852	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	778	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	630	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	738	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	702	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	709	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	625	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	764	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	1015	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	827	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	720	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	837	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	616	n/a
-86	270.0	1.0	incongruent_correct	n/a	1	2	incongruent	920	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	637	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	1233	n/a
-89	277.5	1.0	incongruent_correct	n/a	1	2	incongruent	1143	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	668	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	1184	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	814	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	802	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	719	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	627	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	793	n/a
+2.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	542	n/a
+5.0	1.0	congruent_correct	n/a	1	1	congruent	931	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	966	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	764	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	713	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	662	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	784	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	649	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	693	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	1021	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	767	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	667	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	682	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	780	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	571	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	679	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	995	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	577	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	878	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	513	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	663	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	566	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	758	n/a
+87.5	1.0	incongruent_correct	n/a	1	2	incongruent	875	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	737	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	654	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	643	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	1150	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	620	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	424	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	516	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	679	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	867	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	1081	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	694	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	715	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	784	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	685	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	585	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	630	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	620	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	761	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	581	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	570	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	564	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	562	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	752	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	596	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	847	n/a
+170.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	0	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	770	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	576	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
+185.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	546	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	616	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	675	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	695	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	749	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	634	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	814	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	816	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	687	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	653	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	914	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	654	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	700	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	744	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	852	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	778	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	630	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	738	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	702	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	709	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	625	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	764	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	1015	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	827	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	720	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	837	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	616	n/a
+270.0	1.0	incongruent_correct	n/a	1	2	incongruent	920	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	637	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	1233	n/a
+277.5	1.0	incongruent_correct	n/a	1	2	incongruent	1143	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	668	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	1184	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	814	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	802	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	719	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	627	n/a

--- a/ds101/sub-08/func/sub-08_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-08/func/sub-08_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	665	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	858	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	689	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	599	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	674	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	647	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	645	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	834	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	725	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	675	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	697	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	676	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	777	n/a
-13	42.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	638	n/a
-14	45.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	0	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	736	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	540	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	560	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	710	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	636	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	649	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	540	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	730	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	855	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	550	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	805	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	544	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	654	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	547	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	481	n/a
-31	97.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	444	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	604	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	650	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	968	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	1092	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	608	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	1038	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	996	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	617	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	966	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	716	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	663	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	835	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	641	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	655	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	562	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	566	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	524	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	578	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	395	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	533	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	441	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	728	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	524	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	608	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	653	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	570	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	509	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	540	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	752	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	933	n/a
-69	212.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	938	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	668	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	778	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	799	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	636	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	1024	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	788	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	721	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	790	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	987	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	918	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	562	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	792	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	759	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	732	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	857	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	958	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	599	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	716	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	985	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	590	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	532	n/a
-93	292.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	407	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	669	n/a
-95	297.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	0	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	665	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	858	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	689	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	599	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	674	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	647	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	645	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	834	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	725	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	675	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	697	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	676	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	777	n/a
+42.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	638	n/a
+45.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	0	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	736	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	540	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	560	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	710	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	636	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	649	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	540	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	730	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	855	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	550	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	805	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	544	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	654	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	547	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	481	n/a
+97.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	444	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	604	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	650	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	968	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	1092	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	608	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	1038	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	996	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	617	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	966	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	716	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	663	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	835	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	641	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	655	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	562	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	566	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	524	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	578	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	395	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	533	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	441	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	728	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	524	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	608	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	653	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	570	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	509	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	540	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	752	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	933	n/a
+212.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	938	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	668	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	778	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	799	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	636	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	1024	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	788	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	721	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	790	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	987	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	918	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	562	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	792	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	759	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	732	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	857	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	958	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	599	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	716	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	985	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	590	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	532	n/a
+292.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	407	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	669	n/a
+297.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	0	n/a

--- a/ds101/sub-09/func/sub-09_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-09/func/sub-09_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	559	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	883	n/a
-2	5.0	1.0	congruent_correct	n/a	1	1	congruent	513	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	554	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	908	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	654	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	625	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	538	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	551	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	603	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	773	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	719	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	429	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	542	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	602	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	627	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
-27	87.5	1.0	incongruent_correct	n/a	1	2	incongruent	538	n/a
-28	90.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	581	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	610	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	576	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	452	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	837	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	487	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	571	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	830	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	711	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	723	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	454	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	575	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	581	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	442	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	597	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	515	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	527	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	852	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	456	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	596	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	723	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	641	n/a
-58	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	719	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	316	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	568	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	581	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	538	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	720	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	469	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	857	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	959	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	548	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	481	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	1166	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	403	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	480	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	685	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	482	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	487	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	611	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	433	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	581	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	705	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	558	n/a
-86	270.0	1.0	incongruent_correct	n/a	1	2	incongruent	989	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	575	n/a
-89	277.5	1.0	incongruent_correct	n/a	1	2	incongruent	755	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	600	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	557	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	763	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	599	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	521	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	559	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	883	n/a
+5.0	1.0	congruent_correct	n/a	1	1	congruent	513	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	554	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	908	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	654	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	625	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	538	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	551	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	603	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	773	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	719	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	429	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	542	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	602	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	627	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
+87.5	1.0	incongruent_correct	n/a	1	2	incongruent	538	n/a
+90.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	581	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	610	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	576	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	452	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	837	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	487	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	571	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	830	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	711	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	723	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	454	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	575	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	581	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	442	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	597	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	515	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	527	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	852	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	456	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	596	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	723	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	641	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	719	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	316	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	568	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	581	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	538	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	720	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	469	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	857	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	959	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	548	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	481	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	1166	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	403	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	480	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	685	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	482	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	487	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	611	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	433	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	581	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	705	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	558	n/a
+270.0	1.0	incongruent_correct	n/a	1	2	incongruent	989	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	575	n/a
+277.5	1.0	incongruent_correct	n/a	1	2	incongruent	755	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	600	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	557	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	763	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	599	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	521	n/a

--- a/ds101/sub-09/func/sub-09_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-09/func/sub-09_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	750	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	816	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	427	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	876	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	662	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	603	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	511	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	507	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	481	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	661	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
-16	50.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	572	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	439	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	1117	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	426	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	523	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	617	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	574	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	570	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	585	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	630	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	867	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	439	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	1082	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	424	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	621	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	617	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	622	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	490	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	375	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	630	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	555	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	483	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	368	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	556	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	509	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	643	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	638	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	1221	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	467	n/a
-50	155.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	710	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	644	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	605	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	616	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	566	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	667	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	790	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	556	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	505	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	533	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	694	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	498	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	655	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	900	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	451	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	607	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	587	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	1112	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	430	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	602	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	439	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	628	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	504	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	572	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	705	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	535	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	564	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	623	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	899	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	576	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	464	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	606	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	507	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	761	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	491	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	555	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	750	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	816	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	427	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	876	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	662	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	603	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	511	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	507	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	481	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	661	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
+50.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	572	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	439	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	1117	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	426	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	523	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	617	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	574	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	570	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	585	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	630	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	867	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	439	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	1082	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	424	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	621	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	617	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	622	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	490	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	375	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	630	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	555	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	483	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	368	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	556	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	509	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	643	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	638	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	1221	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	467	n/a
+155.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	710	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	644	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	605	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	616	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	566	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	667	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	790	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	556	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	505	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	533	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	694	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	498	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	655	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	900	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	451	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	607	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	587	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	1112	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	430	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	602	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	439	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	628	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	504	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	572	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	705	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	535	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	564	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	623	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	899	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	576	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	464	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	606	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	507	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	761	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	491	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	555	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a

--- a/ds101/sub-10/func/sub-10_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-10/func/sub-10_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	1	2	incongruent	590	n/a
-1	2.5	1.0	incongruent_correct	1	2	incongruent	492	n/a
-2	5.0	1.0	congruent_correct	1	1	congruent	751	n/a
-3	7.5	1.0	congruent_correct	1	1	congruent	613	n/a
-4	10.0	1.0	incongruent_correct	1	2	incongruent	529	n/a
-5	12.5	1.0	incongruent_correct	1	2	incongruent	421	n/a
-6	20.0	1.0	incongruent_correct	1	2	incongruent	531	n/a
-7	22.5	1.0	incongruent_correct	1	2	incongruent	522	n/a
-8	25.0	1.0	congruent_correct	1	1	congruent	925	n/a
-9	27.5	1.0	congruent_correct	1	1	congruent	393	n/a
-10	30.0	1.0	congruent_incorrect	0	1	congruent	935	n/a
-11	32.5	1.0	congruent_correct	1	1	congruent	882	n/a
-12	45.0	1.0	congruent_correct	1	1	congruent	723	n/a
-13	47.5	1.0	congruent_correct	1	1	congruent	742	n/a
-14	50.0	1.0	incongruent_correct	1	2	incongruent	836	n/a
-15	52.5	1.0	incongruent_correct	1	2	incongruent	527	n/a
-16	55.0	1.0	congruent_correct	1	1	congruent	853	n/a
-17	57.5	1.0	incongruent_correct	1	2	incongruent	874	n/a
-18	65.0	1.0	congruent_correct	1	1	congruent	1327	n/a
-19	67.5	1.0	incongruent_correct	1	2	incongruent	548	n/a
-20	70.0	1.0	incongruent_correct	1	2	incongruent	641	n/a
-21	72.5	1.0	incongruent_correct	1	2	incongruent	518	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	778	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	1038	n/a
-24	80.0	1.0	congruent_incorrect	0	1	congruent	0	n/a
-25	82.5	1.0	congruent_correct	1	1	congruent	407	n/a
-26	85.0	1.0	congruent_correct	1	1	congruent	660	n/a
-27	87.5	1.0	incongruent_correct	1	2	incongruent	537	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	582	n/a
-29	92.5	1.0	congruent_incorrect	0	1	congruent	0	n/a
-30	95.0	1.0	incongruent_correct	1	2	incongruent	600	n/a
-31	97.5	1.0	incongruent_incorrect	0	2	incongruent	0	n/a
-32	100.0	1.0	incongruent_correct	1	2	incongruent	785	n/a
-33	102.5	1.0	incongruent_correct	1	2	incongruent	541	n/a
-34	105.0	1.0	congruent_correct	1	1	congruent	834	n/a
-35	107.5	1.0	congruent_correct	1	1	congruent	471	n/a
-36	110.0	1.0	incongruent_correct	1	2	incongruent	811	n/a
-37	112.5	1.0	incongruent_correct	1	2	incongruent	552	n/a
-38	120.0	1.0	incongruent_correct	1	2	incongruent	589	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	531	n/a
-40	125.0	1.0	congruent_correct	1	1	congruent	536	n/a
-41	127.5	1.0	congruent_correct	1	1	congruent	429	n/a
-42	135.0	1.0	incongruent_correct	1	2	incongruent	682	n/a
-43	137.5	1.0	congruent_correct	1	1	congruent	471	n/a
-44	140.0	1.0	congruent_correct	1	1	congruent	540	n/a
-45	142.5	1.0	incongruent_correct	1	2	incongruent	952	n/a
-46	145.0	1.0	congruent_correct	1	1	congruent	773	n/a
-47	147.5	1.0	incongruent_correct	1	2	incongruent	601	n/a
-48	150.0	1.0	congruent_correct	1	1	congruent	863	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	451	n/a
-50	155.0	1.0	congruent_correct	1	1	congruent	536	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	581	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	592	n/a
-53	162.5	1.0	congruent_correct	1	1	congruent	678	n/a
-54	170.0	1.0	incongruent_correct	1	2	incongruent	531	n/a
-55	172.5	1.0	congruent_correct	1	1	congruent	384	n/a
-56	175.0	1.0	congruent_correct	1	1	congruent	772	n/a
-57	177.5	1.0	incongruent_correct	1	2	incongruent	576	n/a
-58	185.0	1.0	incongruent_correct	1	2	incongruent	591	n/a
-59	187.5	1.0	incongruent_correct	1	2	incongruent	771	n/a
-60	190.0	1.0	incongruent_correct	1	2	incongruent	746	n/a
-61	192.5	1.0	incongruent_correct	1	2	incongruent	494	n/a
-62	195.0	1.0	congruent_incorrect	0	1	congruent	564	n/a
-63	197.5	1.0	congruent_correct	1	1	congruent	518	n/a
-64	200.0	1.0	congruent_correct	1	1	congruent	467	n/a
-65	202.5	1.0	incongruent_correct	1	2	incongruent	735	n/a
-66	205.0	1.0	incongruent_correct	1	2	incongruent	684	n/a
-67	207.5	1.0	incongruent_correct	1	2	incongruent	601	n/a
-68	215.0	1.0	incongruent_correct	1	2	incongruent	775	n/a
-69	217.5	1.0	incongruent_correct	1	2	incongruent	739	n/a
-70	220.0	1.0	congruent_correct	1	1	congruent	648	n/a
-71	222.5	1.0	incongruent_correct	1	2	incongruent	709	n/a
-72	225.0	1.0	incongruent_correct	1	2	incongruent	610	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	991	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	801	n/a
-75	232.5	1.0	congruent_correct	1	1	congruent	872	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	675	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	585	n/a
-78	240.0	1.0	incongruent_correct	1	2	incongruent	581	n/a
-79	242.5	1.0	congruent_correct	1	1	congruent	642	n/a
-80	245.0	1.0	congruent_correct	1	1	congruent	463	n/a
-81	247.5	1.0	incongruent_correct	1	2	incongruent	691	n/a
-82	250.0	1.0	congruent_correct	1	1	congruent	872	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	494	n/a
-84	255.0	1.0	incongruent_correct	1	2	incongruent	649	n/a
-85	257.5	1.0	congruent_correct	1	1	congruent	519	n/a
-86	270.0	1.0	incongruent_correct	1	2	incongruent	893	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	825	n/a
-88	275.0	1.0	congruent_correct	1	1	congruent	687	n/a
-89	277.5	1.0	incongruent_correct	1	2	incongruent	547	n/a
-90	280.0	1.0	incongruent_correct	1	2	incongruent	617	n/a
-91	282.5	1.0	congruent_correct	1	1	congruent	660	n/a
-92	290.0	1.0	congruent_correct	1	1	congruent	883	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	567	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	675	n/a
-95	297.5	1.0	congruent_correct	1	1	congruent	616	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	1	2	incongruent	590	n/a
+2.5	1.0	incongruent_correct	1	2	incongruent	492	n/a
+5.0	1.0	congruent_correct	1	1	congruent	751	n/a
+7.5	1.0	congruent_correct	1	1	congruent	613	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	529	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	421	n/a
+20.0	1.0	incongruent_correct	1	2	incongruent	531	n/a
+22.5	1.0	incongruent_correct	1	2	incongruent	522	n/a
+25.0	1.0	congruent_correct	1	1	congruent	925	n/a
+27.5	1.0	congruent_correct	1	1	congruent	393	n/a
+30.0	1.0	congruent_incorrect	0	1	congruent	935	n/a
+32.5	1.0	congruent_correct	1	1	congruent	882	n/a
+45.0	1.0	congruent_correct	1	1	congruent	723	n/a
+47.5	1.0	congruent_correct	1	1	congruent	742	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	836	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	527	n/a
+55.0	1.0	congruent_correct	1	1	congruent	853	n/a
+57.5	1.0	incongruent_correct	1	2	incongruent	874	n/a
+65.0	1.0	congruent_correct	1	1	congruent	1327	n/a
+67.5	1.0	incongruent_correct	1	2	incongruent	548	n/a
+70.0	1.0	incongruent_correct	1	2	incongruent	641	n/a
+72.5	1.0	incongruent_correct	1	2	incongruent	518	n/a
+75.0	1.0	congruent_correct	1	1	congruent	778	n/a
+77.5	1.0	congruent_correct	1	1	congruent	1038	n/a
+80.0	1.0	congruent_incorrect	0	1	congruent	0	n/a
+82.5	1.0	congruent_correct	1	1	congruent	407	n/a
+85.0	1.0	congruent_correct	1	1	congruent	660	n/a
+87.5	1.0	incongruent_correct	1	2	incongruent	537	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	582	n/a
+92.5	1.0	congruent_incorrect	0	1	congruent	0	n/a
+95.0	1.0	incongruent_correct	1	2	incongruent	600	n/a
+97.5	1.0	incongruent_incorrect	0	2	incongruent	0	n/a
+100.0	1.0	incongruent_correct	1	2	incongruent	785	n/a
+102.5	1.0	incongruent_correct	1	2	incongruent	541	n/a
+105.0	1.0	congruent_correct	1	1	congruent	834	n/a
+107.5	1.0	congruent_correct	1	1	congruent	471	n/a
+110.0	1.0	incongruent_correct	1	2	incongruent	811	n/a
+112.5	1.0	incongruent_correct	1	2	incongruent	552	n/a
+120.0	1.0	incongruent_correct	1	2	incongruent	589	n/a
+122.5	1.0	congruent_correct	1	1	congruent	531	n/a
+125.0	1.0	congruent_correct	1	1	congruent	536	n/a
+127.5	1.0	congruent_correct	1	1	congruent	429	n/a
+135.0	1.0	incongruent_correct	1	2	incongruent	682	n/a
+137.5	1.0	congruent_correct	1	1	congruent	471	n/a
+140.0	1.0	congruent_correct	1	1	congruent	540	n/a
+142.5	1.0	incongruent_correct	1	2	incongruent	952	n/a
+145.0	1.0	congruent_correct	1	1	congruent	773	n/a
+147.5	1.0	incongruent_correct	1	2	incongruent	601	n/a
+150.0	1.0	congruent_correct	1	1	congruent	863	n/a
+152.5	1.0	congruent_correct	1	1	congruent	451	n/a
+155.0	1.0	congruent_correct	1	1	congruent	536	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	581	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	592	n/a
+162.5	1.0	congruent_correct	1	1	congruent	678	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	531	n/a
+172.5	1.0	congruent_correct	1	1	congruent	384	n/a
+175.0	1.0	congruent_correct	1	1	congruent	772	n/a
+177.5	1.0	incongruent_correct	1	2	incongruent	576	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	591	n/a
+187.5	1.0	incongruent_correct	1	2	incongruent	771	n/a
+190.0	1.0	incongruent_correct	1	2	incongruent	746	n/a
+192.5	1.0	incongruent_correct	1	2	incongruent	494	n/a
+195.0	1.0	congruent_incorrect	0	1	congruent	564	n/a
+197.5	1.0	congruent_correct	1	1	congruent	518	n/a
+200.0	1.0	congruent_correct	1	1	congruent	467	n/a
+202.5	1.0	incongruent_correct	1	2	incongruent	735	n/a
+205.0	1.0	incongruent_correct	1	2	incongruent	684	n/a
+207.5	1.0	incongruent_correct	1	2	incongruent	601	n/a
+215.0	1.0	incongruent_correct	1	2	incongruent	775	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	739	n/a
+220.0	1.0	congruent_correct	1	1	congruent	648	n/a
+222.5	1.0	incongruent_correct	1	2	incongruent	709	n/a
+225.0	1.0	incongruent_correct	1	2	incongruent	610	n/a
+227.5	1.0	congruent_correct	1	1	congruent	991	n/a
+230.0	1.0	congruent_correct	1	1	congruent	801	n/a
+232.5	1.0	congruent_correct	1	1	congruent	872	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	675	n/a
+237.5	1.0	congruent_correct	1	1	congruent	585	n/a
+240.0	1.0	incongruent_correct	1	2	incongruent	581	n/a
+242.5	1.0	congruent_correct	1	1	congruent	642	n/a
+245.0	1.0	congruent_correct	1	1	congruent	463	n/a
+247.5	1.0	incongruent_correct	1	2	incongruent	691	n/a
+250.0	1.0	congruent_correct	1	1	congruent	872	n/a
+252.5	1.0	congruent_correct	1	1	congruent	494	n/a
+255.0	1.0	incongruent_correct	1	2	incongruent	649	n/a
+257.5	1.0	congruent_correct	1	1	congruent	519	n/a
+270.0	1.0	incongruent_correct	1	2	incongruent	893	n/a
+272.5	1.0	congruent_correct	1	1	congruent	825	n/a
+275.0	1.0	congruent_correct	1	1	congruent	687	n/a
+277.5	1.0	incongruent_correct	1	2	incongruent	547	n/a
+280.0	1.0	incongruent_correct	1	2	incongruent	617	n/a
+282.5	1.0	congruent_correct	1	1	congruent	660	n/a
+290.0	1.0	congruent_correct	1	1	congruent	883	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	567	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	675	n/a
+297.5	1.0	congruent_correct	1	1	congruent	616	n/a

--- a/ds101/sub-10/func/sub-10_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-10/func/sub-10_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	1	1	congruent	811	n/a
-1	2.5	1.0	congruent_correct	1	1	congruent	464	n/a
-2	10.0	1.0	incongruent_correct	1	2	incongruent	685	n/a
-3	12.5	1.0	incongruent_correct	1	2	incongruent	498	n/a
-4	15.0	1.0	incongruent_correct	1	2	incongruent	566	n/a
-5	17.5	1.0	incongruent_correct	1	2	incongruent	507	n/a
-6	25.0	1.0	congruent_correct	1	1	congruent	802	n/a
-7	27.5	1.0	congruent_correct	1	1	congruent	942	n/a
-8	30.0	1.0	incongruent_correct	1	2	incongruent	586	n/a
-9	32.5	1.0	congruent_correct	1	1	congruent	962	n/a
-10	35.0	1.0	incongruent_correct	1	2	incongruent	620	n/a
-11	37.5	1.0	congruent_correct	1	1	congruent	833	n/a
-12	40.0	1.0	congruent_correct	1	1	congruent	589	n/a
-13	42.5	1.0	incongruent_correct	1	2	incongruent	612	n/a
-14	45.0	1.0	incongruent_correct	1	2	incongruent	518	n/a
-15	47.5	1.0	incongruent_correct	1	2	incongruent	604	n/a
-16	50.0	1.0	incongruent_correct	1	2	incongruent	736	n/a
-17	52.5	1.0	incongruent_correct	1	2	incongruent	573	n/a
-18	60.0	1.0	congruent_correct	1	1	congruent	962	n/a
-19	62.5	1.0	congruent_correct	1	1	congruent	543	n/a
-20	65.0	1.0	congruent_correct	1	1	congruent	549	n/a
-21	67.5	1.0	congruent_correct	1	1	congruent	768	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	863	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	507	n/a
-24	80.0	1.0	congruent_correct	1	1	congruent	560	n/a
-25	82.5	1.0	incongruent_correct	1	2	incongruent	612	n/a
-26	85.0	1.0	incongruent_correct	1	2	incongruent	777	n/a
-27	87.5	1.0	congruent_correct	1	1	congruent	749	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	899	n/a
-29	92.5	1.0	congruent_correct	1	1	congruent	616	n/a
-30	95.0	1.0	congruent_correct	1	1	congruent	644	n/a
-31	97.5	1.0	incongruent_correct	1	2	incongruent	649	n/a
-32	100.0	1.0	congruent_correct	1	1	congruent	712	n/a
-33	102.5	1.0	incongruent_correct	1	2	incongruent	586	n/a
-34	105.0	1.0	incongruent_correct	1	2	incongruent	847	n/a
-35	107.5	1.0	incongruent_correct	1	2	incongruent	995	n/a
-36	110.0	1.0	congruent_correct	1	1	congruent	776	n/a
-37	112.5	1.0	congruent_correct	1	1	congruent	509	n/a
-38	120.0	1.0	congruent_correct	1	1	congruent	738	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	383	n/a
-40	125.0	1.0	congruent_correct	1	1	congruent	1016	n/a
-41	127.5	1.0	congruent_correct	1	1	congruent	497	n/a
-42	130.0	1.0	congruent_correct	1	1	congruent	542	n/a
-43	132.5	1.0	incongruent_correct	1	2	incongruent	785	n/a
-44	135.0	1.0	congruent_correct	1	1	congruent	782	n/a
-45	137.5	1.0	incongruent_correct	1	2	incongruent	771	n/a
-46	140.0	1.0	congruent_correct	1	1	congruent	1024	n/a
-47	142.5	1.0	incongruent_incorrect	0	2	incongruent	380	n/a
-48	150.0	1.0	incongruent_correct	1	2	incongruent	820	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	1045	n/a
-50	155.0	1.0	incongruent_correct	1	2	incongruent	1159	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	763	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	799	n/a
-53	162.5	1.0	incongruent_correct	1	2	incongruent	908	n/a
-54	165.0	1.0	incongruent_correct	1	2	incongruent	643	n/a
-55	167.5	1.0	incongruent_correct	1	2	incongruent	509	n/a
-56	170.0	1.0	incongruent_correct	1	2	incongruent	979	n/a
-57	172.5	1.0	incongruent_correct	1	2	incongruent	608	n/a
-58	175.0	1.0	congruent_incorrect	0	1	congruent	988	n/a
-59	177.5	1.0	congruent_correct	1	1	congruent	646	n/a
-60	185.0	1.0	incongruent_correct	1	2	incongruent	644	n/a
-61	187.5	1.0	congruent_correct	1	1	congruent	685	n/a
-62	190.0	1.0	congruent_correct	1	1	congruent	634	n/a
-63	192.5	1.0	incongruent_correct	1	2	incongruent	587	n/a
-64	195.0	1.0	incongruent_correct	1	2	incongruent	587	n/a
-65	197.5	1.0	incongruent_correct	1	2	incongruent	672	n/a
-66	200.0	1.0	incongruent_correct	1	2	incongruent	833	n/a
-67	202.5	1.0	congruent_correct	1	1	congruent	772	n/a
-68	210.0	1.0	incongruent_correct	1	2	incongruent	740	n/a
-69	212.5	1.0	incongruent_correct	1	2	incongruent	570	n/a
-70	215.0	1.0	congruent_correct	1	1	congruent	634	n/a
-71	217.5	1.0	incongruent_correct	1	2	incongruent	1073	n/a
-72	225.0	1.0	congruent_correct	1	1	congruent	785	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	660	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	749	n/a
-75	232.5	1.0	congruent_correct	1	1	congruent	621	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	612	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	561	n/a
-78	240.0	1.0	congruent_correct	1	1	congruent	604	n/a
-79	242.5	1.0	incongruent_incorrect	0	2	incongruent	792	n/a
-80	245.0	1.0	incongruent_incorrect	0	2	incongruent	516	n/a
-81	247.5	1.0	congruent_incorrect	0	1	congruent	603	n/a
-82	250.0	1.0	incongruent_correct	1	2	incongruent	648	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	507	n/a
-84	260.0	1.0	incongruent_correct	1	2	incongruent	627	n/a
-85	262.5	1.0	congruent_correct	1	1	congruent	710	n/a
-86	270.0	1.0	congruent_correct	1	1	congruent	716	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	535	n/a
-88	275.0	1.0	incongruent_correct	1	2	incongruent	558	n/a
-89	277.5	1.0	congruent_correct	1	1	congruent	409	n/a
-90	285.0	1.0	congruent_correct	1	1	congruent	747	n/a
-91	287.5	1.0	incongruent_correct	1	2	incongruent	493	n/a
-92	290.0	1.0	congruent_correct	1	1	congruent	555	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	576	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	500	n/a
-95	297.5	1.0	incongruent_correct	1	2	incongruent	644	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	1	1	congruent	811	n/a
+2.5	1.0	congruent_correct	1	1	congruent	464	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	685	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	498	n/a
+15.0	1.0	incongruent_correct	1	2	incongruent	566	n/a
+17.5	1.0	incongruent_correct	1	2	incongruent	507	n/a
+25.0	1.0	congruent_correct	1	1	congruent	802	n/a
+27.5	1.0	congruent_correct	1	1	congruent	942	n/a
+30.0	1.0	incongruent_correct	1	2	incongruent	586	n/a
+32.5	1.0	congruent_correct	1	1	congruent	962	n/a
+35.0	1.0	incongruent_correct	1	2	incongruent	620	n/a
+37.5	1.0	congruent_correct	1	1	congruent	833	n/a
+40.0	1.0	congruent_correct	1	1	congruent	589	n/a
+42.5	1.0	incongruent_correct	1	2	incongruent	612	n/a
+45.0	1.0	incongruent_correct	1	2	incongruent	518	n/a
+47.5	1.0	incongruent_correct	1	2	incongruent	604	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	736	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	573	n/a
+60.0	1.0	congruent_correct	1	1	congruent	962	n/a
+62.5	1.0	congruent_correct	1	1	congruent	543	n/a
+65.0	1.0	congruent_correct	1	1	congruent	549	n/a
+67.5	1.0	congruent_correct	1	1	congruent	768	n/a
+75.0	1.0	congruent_correct	1	1	congruent	863	n/a
+77.5	1.0	congruent_correct	1	1	congruent	507	n/a
+80.0	1.0	congruent_correct	1	1	congruent	560	n/a
+82.5	1.0	incongruent_correct	1	2	incongruent	612	n/a
+85.0	1.0	incongruent_correct	1	2	incongruent	777	n/a
+87.5	1.0	congruent_correct	1	1	congruent	749	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	899	n/a
+92.5	1.0	congruent_correct	1	1	congruent	616	n/a
+95.0	1.0	congruent_correct	1	1	congruent	644	n/a
+97.5	1.0	incongruent_correct	1	2	incongruent	649	n/a
+100.0	1.0	congruent_correct	1	1	congruent	712	n/a
+102.5	1.0	incongruent_correct	1	2	incongruent	586	n/a
+105.0	1.0	incongruent_correct	1	2	incongruent	847	n/a
+107.5	1.0	incongruent_correct	1	2	incongruent	995	n/a
+110.0	1.0	congruent_correct	1	1	congruent	776	n/a
+112.5	1.0	congruent_correct	1	1	congruent	509	n/a
+120.0	1.0	congruent_correct	1	1	congruent	738	n/a
+122.5	1.0	congruent_correct	1	1	congruent	383	n/a
+125.0	1.0	congruent_correct	1	1	congruent	1016	n/a
+127.5	1.0	congruent_correct	1	1	congruent	497	n/a
+130.0	1.0	congruent_correct	1	1	congruent	542	n/a
+132.5	1.0	incongruent_correct	1	2	incongruent	785	n/a
+135.0	1.0	congruent_correct	1	1	congruent	782	n/a
+137.5	1.0	incongruent_correct	1	2	incongruent	771	n/a
+140.0	1.0	congruent_correct	1	1	congruent	1024	n/a
+142.5	1.0	incongruent_incorrect	0	2	incongruent	380	n/a
+150.0	1.0	incongruent_correct	1	2	incongruent	820	n/a
+152.5	1.0	congruent_correct	1	1	congruent	1045	n/a
+155.0	1.0	incongruent_correct	1	2	incongruent	1159	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	763	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	799	n/a
+162.5	1.0	incongruent_correct	1	2	incongruent	908	n/a
+165.0	1.0	incongruent_correct	1	2	incongruent	643	n/a
+167.5	1.0	incongruent_correct	1	2	incongruent	509	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	979	n/a
+172.5	1.0	incongruent_correct	1	2	incongruent	608	n/a
+175.0	1.0	congruent_incorrect	0	1	congruent	988	n/a
+177.5	1.0	congruent_correct	1	1	congruent	646	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	644	n/a
+187.5	1.0	congruent_correct	1	1	congruent	685	n/a
+190.0	1.0	congruent_correct	1	1	congruent	634	n/a
+192.5	1.0	incongruent_correct	1	2	incongruent	587	n/a
+195.0	1.0	incongruent_correct	1	2	incongruent	587	n/a
+197.5	1.0	incongruent_correct	1	2	incongruent	672	n/a
+200.0	1.0	incongruent_correct	1	2	incongruent	833	n/a
+202.5	1.0	congruent_correct	1	1	congruent	772	n/a
+210.0	1.0	incongruent_correct	1	2	incongruent	740	n/a
+212.5	1.0	incongruent_correct	1	2	incongruent	570	n/a
+215.0	1.0	congruent_correct	1	1	congruent	634	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	1073	n/a
+225.0	1.0	congruent_correct	1	1	congruent	785	n/a
+227.5	1.0	congruent_correct	1	1	congruent	660	n/a
+230.0	1.0	congruent_correct	1	1	congruent	749	n/a
+232.5	1.0	congruent_correct	1	1	congruent	621	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	612	n/a
+237.5	1.0	congruent_correct	1	1	congruent	561	n/a
+240.0	1.0	congruent_correct	1	1	congruent	604	n/a
+242.5	1.0	incongruent_incorrect	0	2	incongruent	792	n/a
+245.0	1.0	incongruent_incorrect	0	2	incongruent	516	n/a
+247.5	1.0	congruent_incorrect	0	1	congruent	603	n/a
+250.0	1.0	incongruent_correct	1	2	incongruent	648	n/a
+252.5	1.0	congruent_correct	1	1	congruent	507	n/a
+260.0	1.0	incongruent_correct	1	2	incongruent	627	n/a
+262.5	1.0	congruent_correct	1	1	congruent	710	n/a
+270.0	1.0	congruent_correct	1	1	congruent	716	n/a
+272.5	1.0	congruent_correct	1	1	congruent	535	n/a
+275.0	1.0	incongruent_correct	1	2	incongruent	558	n/a
+277.5	1.0	congruent_correct	1	1	congruent	409	n/a
+285.0	1.0	congruent_correct	1	1	congruent	747	n/a
+287.5	1.0	incongruent_correct	1	2	incongruent	493	n/a
+290.0	1.0	congruent_correct	1	1	congruent	555	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	576	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	500	n/a
+297.5	1.0	incongruent_correct	1	2	incongruent	644	n/a

--- a/ds101/sub-11/func/sub-11_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-11/func/sub-11_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	1	2	incongruent	679	n/a
-1	2.5	1.0	incongruent_correct	1	2	incongruent	532	n/a
-2	5.0	1.0	congruent_correct	1	1	congruent	509	n/a
-3	7.5	1.0	congruent_correct	1	1	congruent	502	n/a
-4	10.0	1.0	incongruent_correct	1	2	incongruent	531	n/a
-5	12.5	1.0	incongruent_correct	1	2	incongruent	439	n/a
-6	20.0	1.0	incongruent_correct	1	2	incongruent	573	n/a
-7	22.5	1.0	incongruent_correct	1	2	incongruent	441	n/a
-8	25.0	1.0	congruent_correct	1	1	congruent	560	n/a
-9	27.5	1.0	congruent_correct	1	1	congruent	509	n/a
-10	30.0	1.0	congruent_correct	1	1	congruent	607	n/a
-11	32.5	1.0	congruent_correct	1	1	congruent	315	n/a
-12	45.0	1.0	congruent_correct	1	1	congruent	456	n/a
-13	47.5	1.0	congruent_correct	1	1	congruent	384	n/a
-14	50.0	1.0	incongruent_correct	1	2	incongruent	501	n/a
-15	52.5	1.0	incongruent_correct	1	2	incongruent	418	n/a
-16	55.0	1.0	congruent_correct	1	1	congruent	454	n/a
-17	57.5	1.0	incongruent_correct	1	2	incongruent	427	n/a
-18	65.0	1.0	congruent_correct	1	1	congruent	449	n/a
-19	67.5	1.0	incongruent_correct	1	2	incongruent	509	n/a
-20	70.0	1.0	incongruent_correct	1	2	incongruent	394	n/a
-21	72.5	1.0	incongruent_correct	1	2	incongruent	560	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	668	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	440	n/a
-24	80.0	1.0	congruent_correct	1	1	congruent	492	n/a
-25	82.5	1.0	congruent_correct	1	1	congruent	434	n/a
-26	85.0	1.0	congruent_correct	1	1	congruent	422	n/a
-27	87.5	1.0	incongruent_correct	1	2	incongruent	508	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	352	n/a
-29	92.5	1.0	congruent_incorrect	0	1	congruent	436	n/a
-30	95.0	1.0	incongruent_correct	1	2	incongruent	528	n/a
-31	97.5	1.0	incongruent_correct	1	2	incongruent	389	n/a
-32	100.0	1.0	incongruent_correct	1	2	incongruent	386	n/a
-33	102.5	1.0	incongruent_correct	1	2	incongruent	502	n/a
-34	105.0	1.0	congruent_correct	1	1	congruent	723	n/a
-35	107.5	1.0	congruent_correct	1	1	congruent	487	n/a
-36	110.0	1.0	incongruent_correct	1	2	incongruent	573	n/a
-37	112.5	1.0	incongruent_correct	1	2	incongruent	585	n/a
-38	120.0	1.0	incongruent_correct	1	2	incongruent	535	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	796	n/a
-40	125.0	1.0	congruent_correct	1	1	congruent	544	n/a
-41	127.5	1.0	congruent_correct	1	1	congruent	445	n/a
-42	135.0	1.0	incongruent_correct	1	2	incongruent	530	n/a
-43	137.5	1.0	congruent_correct	1	1	congruent	560	n/a
-44	140.0	1.0	congruent_correct	1	1	congruent	453	n/a
-45	142.5	1.0	incongruent_correct	1	2	incongruent	497	n/a
-46	145.0	1.0	congruent_correct	1	1	congruent	399	n/a
-47	147.5	1.0	incongruent_correct	1	2	incongruent	490	n/a
-48	150.0	1.0	congruent_correct	1	1	congruent	430	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	491	n/a
-50	155.0	1.0	congruent_correct	1	1	congruent	328	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	476	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	529	n/a
-53	162.5	1.0	congruent_correct	1	1	congruent	502	n/a
-54	170.0	1.0	incongruent_correct	1	2	incongruent	511	n/a
-55	172.5	1.0	congruent_correct	1	1	congruent	633	n/a
-56	175.0	1.0	congruent_correct	1	1	congruent	566	n/a
-57	177.5	1.0	incongruent_correct	1	2	incongruent	458	n/a
-58	185.0	1.0	incongruent_correct	1	2	incongruent	439	n/a
-59	187.5	1.0	incongruent_correct	1	2	incongruent	617	n/a
-60	190.0	1.0	incongruent_correct	1	2	incongruent	449	n/a
-61	192.5	1.0	incongruent_correct	1	2	incongruent	438	n/a
-62	195.0	1.0	congruent_correct	1	1	congruent	595	n/a
-63	197.5	1.0	congruent_correct	1	1	congruent	320	n/a
-64	200.0	1.0	congruent_correct	1	1	congruent	435	n/a
-65	202.5	1.0	incongruent_incorrect	0	2	incongruent	249	n/a
-66	205.0	1.0	incongruent_correct	1	2	incongruent	582	n/a
-67	207.5	1.0	incongruent_correct	1	2	incongruent	387	n/a
-68	215.0	1.0	incongruent_correct	1	2	incongruent	488	n/a
-69	217.5	1.0	incongruent_correct	1	2	incongruent	453	n/a
-70	220.0	1.0	congruent_correct	1	1	congruent	329	n/a
-71	222.5	1.0	incongruent_correct	1	2	incongruent	495	n/a
-72	225.0	1.0	incongruent_correct	1	2	incongruent	482	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	392	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	420	n/a
-75	232.5	1.0	congruent_correct	1	1	congruent	465	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	478	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	571	n/a
-78	240.0	1.0	incongruent_correct	1	2	incongruent	527	n/a
-79	242.5	1.0	congruent_correct	1	1	congruent	444	n/a
-80	245.0	1.0	congruent_correct	1	1	congruent	353	n/a
-81	247.5	1.0	incongruent_correct	1	2	incongruent	469	n/a
-82	250.0	1.0	congruent_correct	1	1	congruent	425	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	518	n/a
-84	255.0	1.0	incongruent_correct	1	2	incongruent	522	n/a
-85	257.5	1.0	congruent_correct	1	1	congruent	422	n/a
-86	270.0	1.0	incongruent_correct	1	2	incongruent	506	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	493	n/a
-88	275.0	1.0	congruent_correct	1	1	congruent	568	n/a
-89	277.5	1.0	incongruent_correct	1	2	incongruent	508	n/a
-90	280.0	1.0	incongruent_correct	1	2	incongruent	465	n/a
-91	282.5	1.0	congruent_correct	1	1	congruent	391	n/a
-92	290.0	1.0	congruent_correct	1	1	congruent	500	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	448	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	437	n/a
-95	297.5	1.0	congruent_correct	1	1	congruent	513	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	1	2	incongruent	679	n/a
+2.5	1.0	incongruent_correct	1	2	incongruent	532	n/a
+5.0	1.0	congruent_correct	1	1	congruent	509	n/a
+7.5	1.0	congruent_correct	1	1	congruent	502	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	531	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	439	n/a
+20.0	1.0	incongruent_correct	1	2	incongruent	573	n/a
+22.5	1.0	incongruent_correct	1	2	incongruent	441	n/a
+25.0	1.0	congruent_correct	1	1	congruent	560	n/a
+27.5	1.0	congruent_correct	1	1	congruent	509	n/a
+30.0	1.0	congruent_correct	1	1	congruent	607	n/a
+32.5	1.0	congruent_correct	1	1	congruent	315	n/a
+45.0	1.0	congruent_correct	1	1	congruent	456	n/a
+47.5	1.0	congruent_correct	1	1	congruent	384	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	501	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	418	n/a
+55.0	1.0	congruent_correct	1	1	congruent	454	n/a
+57.5	1.0	incongruent_correct	1	2	incongruent	427	n/a
+65.0	1.0	congruent_correct	1	1	congruent	449	n/a
+67.5	1.0	incongruent_correct	1	2	incongruent	509	n/a
+70.0	1.0	incongruent_correct	1	2	incongruent	394	n/a
+72.5	1.0	incongruent_correct	1	2	incongruent	560	n/a
+75.0	1.0	congruent_correct	1	1	congruent	668	n/a
+77.5	1.0	congruent_correct	1	1	congruent	440	n/a
+80.0	1.0	congruent_correct	1	1	congruent	492	n/a
+82.5	1.0	congruent_correct	1	1	congruent	434	n/a
+85.0	1.0	congruent_correct	1	1	congruent	422	n/a
+87.5	1.0	incongruent_correct	1	2	incongruent	508	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	352	n/a
+92.5	1.0	congruent_incorrect	0	1	congruent	436	n/a
+95.0	1.0	incongruent_correct	1	2	incongruent	528	n/a
+97.5	1.0	incongruent_correct	1	2	incongruent	389	n/a
+100.0	1.0	incongruent_correct	1	2	incongruent	386	n/a
+102.5	1.0	incongruent_correct	1	2	incongruent	502	n/a
+105.0	1.0	congruent_correct	1	1	congruent	723	n/a
+107.5	1.0	congruent_correct	1	1	congruent	487	n/a
+110.0	1.0	incongruent_correct	1	2	incongruent	573	n/a
+112.5	1.0	incongruent_correct	1	2	incongruent	585	n/a
+120.0	1.0	incongruent_correct	1	2	incongruent	535	n/a
+122.5	1.0	congruent_correct	1	1	congruent	796	n/a
+125.0	1.0	congruent_correct	1	1	congruent	544	n/a
+127.5	1.0	congruent_correct	1	1	congruent	445	n/a
+135.0	1.0	incongruent_correct	1	2	incongruent	530	n/a
+137.5	1.0	congruent_correct	1	1	congruent	560	n/a
+140.0	1.0	congruent_correct	1	1	congruent	453	n/a
+142.5	1.0	incongruent_correct	1	2	incongruent	497	n/a
+145.0	1.0	congruent_correct	1	1	congruent	399	n/a
+147.5	1.0	incongruent_correct	1	2	incongruent	490	n/a
+150.0	1.0	congruent_correct	1	1	congruent	430	n/a
+152.5	1.0	congruent_correct	1	1	congruent	491	n/a
+155.0	1.0	congruent_correct	1	1	congruent	328	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	476	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	529	n/a
+162.5	1.0	congruent_correct	1	1	congruent	502	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	511	n/a
+172.5	1.0	congruent_correct	1	1	congruent	633	n/a
+175.0	1.0	congruent_correct	1	1	congruent	566	n/a
+177.5	1.0	incongruent_correct	1	2	incongruent	458	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	439	n/a
+187.5	1.0	incongruent_correct	1	2	incongruent	617	n/a
+190.0	1.0	incongruent_correct	1	2	incongruent	449	n/a
+192.5	1.0	incongruent_correct	1	2	incongruent	438	n/a
+195.0	1.0	congruent_correct	1	1	congruent	595	n/a
+197.5	1.0	congruent_correct	1	1	congruent	320	n/a
+200.0	1.0	congruent_correct	1	1	congruent	435	n/a
+202.5	1.0	incongruent_incorrect	0	2	incongruent	249	n/a
+205.0	1.0	incongruent_correct	1	2	incongruent	582	n/a
+207.5	1.0	incongruent_correct	1	2	incongruent	387	n/a
+215.0	1.0	incongruent_correct	1	2	incongruent	488	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	453	n/a
+220.0	1.0	congruent_correct	1	1	congruent	329	n/a
+222.5	1.0	incongruent_correct	1	2	incongruent	495	n/a
+225.0	1.0	incongruent_correct	1	2	incongruent	482	n/a
+227.5	1.0	congruent_correct	1	1	congruent	392	n/a
+230.0	1.0	congruent_correct	1	1	congruent	420	n/a
+232.5	1.0	congruent_correct	1	1	congruent	465	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	478	n/a
+237.5	1.0	congruent_correct	1	1	congruent	571	n/a
+240.0	1.0	incongruent_correct	1	2	incongruent	527	n/a
+242.5	1.0	congruent_correct	1	1	congruent	444	n/a
+245.0	1.0	congruent_correct	1	1	congruent	353	n/a
+247.5	1.0	incongruent_correct	1	2	incongruent	469	n/a
+250.0	1.0	congruent_correct	1	1	congruent	425	n/a
+252.5	1.0	congruent_correct	1	1	congruent	518	n/a
+255.0	1.0	incongruent_correct	1	2	incongruent	522	n/a
+257.5	1.0	congruent_correct	1	1	congruent	422	n/a
+270.0	1.0	incongruent_correct	1	2	incongruent	506	n/a
+272.5	1.0	congruent_correct	1	1	congruent	493	n/a
+275.0	1.0	congruent_correct	1	1	congruent	568	n/a
+277.5	1.0	incongruent_correct	1	2	incongruent	508	n/a
+280.0	1.0	incongruent_correct	1	2	incongruent	465	n/a
+282.5	1.0	congruent_correct	1	1	congruent	391	n/a
+290.0	1.0	congruent_correct	1	1	congruent	500	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	448	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	437	n/a
+297.5	1.0	congruent_correct	1	1	congruent	513	n/a

--- a/ds101/sub-11/func/sub-11_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-11/func/sub-11_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	737	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	556	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	450	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	398	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	434	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	592	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	548	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	598	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	451	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	360	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	598	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	358	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	372	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	438	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	464	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	327	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	445	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	442	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	310	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	338	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	399	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	421	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	351	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	635	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	537	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	362	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	423	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	587	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
-45	137.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	442	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	535	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	492	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	341	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	382	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	431	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	488	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	428	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	523	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	691	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	509	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	410	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	659	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	617	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	518	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	716	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	613	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	519	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	291	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	477	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	317	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	480	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	765	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	857	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	511	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	549	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	554	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	564	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	737	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	556	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	450	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	398	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	434	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	592	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	548	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	598	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	451	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	360	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	598	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	358	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	372	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	438	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	464	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	419	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	327	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	445	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	442	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	310	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	338	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	399	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	421	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	351	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	635	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	537	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	362	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	423	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	587	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
+137.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	442	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	535	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	492	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	341	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	382	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	431	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	488	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	428	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	523	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	691	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	509	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	410	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	659	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	617	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	518	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	716	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	613	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	519	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	291	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	477	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	317	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	480	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	765	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	857	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	511	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	549	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	554	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	564	n/a

--- a/ds101/sub-12/func/sub-12_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-12/func/sub-12_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	520	n/a
-1	2.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	447	n/a
-2	5.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	381	n/a
-3	7.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	349	n/a
-4	10.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	467	n/a
-5	12.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	370	n/a
-6	20.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	526	n/a
-7	22.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	462	n/a
-8	25.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	364	n/a
-9	27.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	324	n/a
-10	30.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	427	n/a
-11	32.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	329	n/a
-12	45.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	476	n/a
-13	47.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	386	n/a
-14	50.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	490	n/a
-15	52.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	480	n/a
-16	55.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	423	n/a
-17	57.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	366	n/a
-18	65.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	515	n/a
-19	67.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	490	n/a
-20	70.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	369	n/a
-21	72.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	360	n/a
-22	75.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	598	n/a
-23	77.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	317	n/a
-24	80.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	380	n/a
-25	82.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	331	n/a
-26	85.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	449	n/a
-27	87.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	520	n/a
-28	90.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	439	n/a
-29	92.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	358	n/a
-30	95.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	397	n/a
-31	97.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	611	n/a
-32	100.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	523	n/a
-33	102.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	353	n/a
-34	105.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	408	n/a
-35	107.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	343	n/a
-36	110.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	494	n/a
-37	112.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	356	n/a
-38	120.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	569	n/a
-39	122.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	352	n/a
-40	125.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	367	n/a
-41	127.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	413	n/a
-42	135.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	547	n/a
-43	137.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	458	n/a
-44	140.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	337	n/a
-45	142.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	464	n/a
-46	145.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	334	n/a
-47	147.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	421	n/a
-48	150.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	436	n/a
-49	152.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	323	n/a
-50	155.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	425	n/a
-51	157.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	464	n/a
-52	160.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	367	n/a
-53	162.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	446	n/a
-54	170.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	619	n/a
-55	172.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	394	n/a
-56	175.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	369	n/a
-57	177.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	415	n/a
-58	185.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	580	n/a
-59	187.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	395	n/a
-60	190.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	450	n/a
-61	192.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	489	n/a
-62	195.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	432	n/a
-63	197.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	351	n/a
-64	200.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	461	n/a
-65	202.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	541	n/a
-66	205.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	435	n/a
-67	207.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	450	n/a
-68	215.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	566	n/a
-69	217.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	374	n/a
-70	220.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	380	n/a
-71	222.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
-72	225.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	394	n/a
-73	227.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	497	n/a
-74	230.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	327	n/a
-75	232.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	359	n/a
-76	235.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	486	n/a
-77	237.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	388	n/a
-78	240.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	459	n/a
-79	242.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	426	n/a
-80	245.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	329	n/a
-81	247.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	351	n/a
-82	250.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	374	n/a
-83	252.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	373	n/a
-84	255.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	436	n/a
-85	257.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	418	n/a
-86	270.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	637	n/a
-87	272.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	381	n/a
-88	275.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	363	n/a
-89	277.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	458	n/a
-90	280.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	352	n/a
-91	282.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	368	n/a
-92	290.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	516	n/a
-93	292.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	435	n/a
-94	295.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	530	n/a
-95	297.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	337	n/a
+onset	duration	trial_type	congruent_incorrect	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	520	n/a
+2.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	447	n/a
+5.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	381	n/a
+7.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	349	n/a
+10.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	467	n/a
+12.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	370	n/a
+20.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	526	n/a
+22.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	462	n/a
+25.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	364	n/a
+27.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	324	n/a
+30.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	427	n/a
+32.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	329	n/a
+45.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	476	n/a
+47.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	386	n/a
+50.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	490	n/a
+52.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	480	n/a
+55.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	423	n/a
+57.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	366	n/a
+65.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	515	n/a
+67.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	490	n/a
+70.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	369	n/a
+72.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	360	n/a
+75.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	598	n/a
+77.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	317	n/a
+80.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	380	n/a
+82.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	331	n/a
+85.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	449	n/a
+87.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	520	n/a
+90.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	439	n/a
+92.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	358	n/a
+95.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	397	n/a
+97.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	611	n/a
+100.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	523	n/a
+102.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	353	n/a
+105.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	408	n/a
+107.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	343	n/a
+110.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	494	n/a
+112.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	356	n/a
+120.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	569	n/a
+122.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	352	n/a
+125.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	367	n/a
+127.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	413	n/a
+135.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	547	n/a
+137.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	458	n/a
+140.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	337	n/a
+142.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	464	n/a
+145.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	334	n/a
+147.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	421	n/a
+150.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	436	n/a
+152.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	323	n/a
+155.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	425	n/a
+157.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	464	n/a
+160.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	367	n/a
+162.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	446	n/a
+170.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	619	n/a
+172.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	394	n/a
+175.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	369	n/a
+177.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	415	n/a
+185.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	580	n/a
+187.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	395	n/a
+190.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	450	n/a
+192.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	489	n/a
+195.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	432	n/a
+197.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	351	n/a
+200.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	461	n/a
+202.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	541	n/a
+205.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	435	n/a
+207.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	450	n/a
+215.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	566	n/a
+217.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	374	n/a
+220.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	380	n/a
+222.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
+225.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	394	n/a
+227.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	497	n/a
+230.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	327	n/a
+232.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	359	n/a
+235.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	486	n/a
+237.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	388	n/a
+240.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	459	n/a
+242.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	426	n/a
+245.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	329	n/a
+247.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	351	n/a
+250.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	374	n/a
+252.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	373	n/a
+255.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	436	n/a
+257.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	418	n/a
+270.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	637	n/a
+272.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	381	n/a
+275.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	363	n/a
+277.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	458	n/a
+280.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	352	n/a
+282.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	368	n/a
+290.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	516	n/a
+292.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	435	n/a
+295.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	530	n/a
+297.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	337	n/a

--- a/ds101/sub-12/func/sub-12_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-12/func/sub-12_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	489	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	377	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	332	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	655	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	294	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	367	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	477	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	323	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	338	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	518	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	326	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	324	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	316	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	335	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	311	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	428	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	442	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	328	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	383	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	486	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	387	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	409	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	328	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	367	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	315	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	401	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	329	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
-43	132.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	350	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	380	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	569	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	550	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	452	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	362	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	458	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	376	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	455	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	382	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	365	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	441	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	598	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	449	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	416	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	423	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	530	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	386	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	676	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	347	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	330	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	512	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	333	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	412	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	330	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	368	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	604	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	380	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	430	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	365	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	682	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	432	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	366	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	430	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	380	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	489	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	377	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	332	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	655	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	294	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	367	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	477	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	323	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	338	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	518	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	326	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	324	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	316	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	335	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	311	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	428	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	442	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	328	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	383	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	486	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	387	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	409	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	328	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	367	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	315	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	401	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	329	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	503	n/a
+132.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	350	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	380	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	569	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	550	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	452	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	362	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	458	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	376	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	455	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	382	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	365	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	441	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	598	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	449	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	416	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	423	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	530	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	386	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	676	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	347	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	330	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	512	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	333	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	412	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	330	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	368	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	604	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	380	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	430	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	365	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	682	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	432	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	366	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	430	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	380	n/a

--- a/ds101/sub-13/func/sub-13_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-13/func/sub-13_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	1	2	incongruent	755	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
-2	5.0	1.0	congruent_correct	n/a	1	1	congruent	423	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	347	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	635	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	470	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	547	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	425	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	513	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	454	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	528	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	544	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	613	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	426	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
-27	87.5	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	493	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	378	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	542	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	435	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	456	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	568	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	589	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	402	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	382	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	528	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	380	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	606	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	520	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	452	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	385	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	520	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	586	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	381	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-58	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	590	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	442	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	583	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	608	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	466	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	702	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	499	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	432	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	407	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
-76	235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	362	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	563	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	463	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	527	n/a
-86	270.0	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	385	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
-89	277.5	1.0	incongruent_correct	n/a	1	2	incongruent	507	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	433	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	376	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	1	2	incongruent	755	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
+5.0	1.0	congruent_correct	n/a	1	1	congruent	423	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	347	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	635	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	470	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	547	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	425	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	513	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	454	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	528	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	544	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	613	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	426	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
+87.5	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	493	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	378	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	542	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	435	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	456	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	568	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	589	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	402	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	382	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	528	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	380	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	606	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	520	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	452	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	385	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	520	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	586	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	381	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	379	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	590	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	442	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	583	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	608	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	466	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	702	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	499	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	432	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	407	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
+235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	362	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	563	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	463	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	461	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	527	n/a
+270.0	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	385	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
+277.5	1.0	incongruent_correct	n/a	1	2	incongruent	507	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	433	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	376	n/a

--- a/ds101/sub-13/func/sub-13_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-13/func/sub-13_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	497	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	446	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	580	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	556	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
-8	30.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	409	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	715	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	512	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	725	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	600	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	493	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	658	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	614	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	954	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	656	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	399	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	477	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	466	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	361	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	410	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	488	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	473	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	407	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	370	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	382	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	512	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	473	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	576	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	438	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	539	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	453	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	417	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	606	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	512	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	382	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	403	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	536	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	430	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	506	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	584	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	401	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	463	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	499	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	378	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	372	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	344	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	477	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	417	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	434	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	447	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	457	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	624	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	493	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	457	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	504	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	374	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	388	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	497	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	446	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	580	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	448	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	556	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
+30.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	409	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	486	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	715	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	512	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	725	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	600	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	493	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	658	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	614	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	954	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	656	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	399	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	477	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	466	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	361	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	410	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	488	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	444	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	473	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	407	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	370	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	417	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	382	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	512	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	473	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	576	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	438	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	539	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	453	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	417	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	606	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	512	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	382	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	403	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	536	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	430	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	506	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	584	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	401	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	463	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	499	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	378	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	372	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	344	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	477	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	417	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	434	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	447	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	457	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	624	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	493	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	457	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	504	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	374	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	388	n/a

--- a/ds101/sub-14/func/sub-14_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-14/func/sub-14_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	1	2	incongruent	615	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	550	n/a
-2	5.0	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	794	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	749	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	541	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	352	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	547	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	422	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	641	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	481	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	351	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	362	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	330	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	520	n/a
-27	87.5	1.0	incongruent_correct	n/a	1	2	incongruent	487	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	538	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	544	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	511	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	920	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	359	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	625	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	505	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	527	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	477	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	540	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	402	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	369	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	565	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	786	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	425	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-58	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	755	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	498	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	577	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	455	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	653	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	532	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	594	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	593	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	589	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	517	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	467	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	458	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	664	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
-76	235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	429	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	554	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	368	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	574	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	469	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	668	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	529	n/a
-86	270.0	1.0	incongruent_correct	n/a	1	2	incongruent	676	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	411	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
-89	277.5	1.0	incongruent_correct	n/a	1	2	incongruent	529	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	375	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	318	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	859	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	1	2	incongruent	615	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	550	n/a
+5.0	1.0	congruent_correct	n/a	1	1	congruent	396	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	420	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	794	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	749	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	541	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	352	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	547	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	422	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	641	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	481	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	351	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	485	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	362	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	330	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	520	n/a
+87.5	1.0	incongruent_correct	n/a	1	2	incongruent	487	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	510	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	538	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	544	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	511	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	920	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	359	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	625	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	505	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	527	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	477	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	540	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	402	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	346	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	369	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	565	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	786	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	425	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	392	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	755	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	498	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	577	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	455	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	653	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	532	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	594	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	593	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	589	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	517	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	467	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	458	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	664	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
+235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	429	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	554	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	368	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	574	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	469	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	668	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	529	n/a
+270.0	1.0	incongruent_correct	n/a	1	2	incongruent	676	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	411	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
+277.5	1.0	incongruent_correct	n/a	1	2	incongruent	529	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	375	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	318	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	859	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	514	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	400	n/a

--- a/ds101/sub-14/func/sub-14_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-14/func/sub-14_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	754	n/a
-1	2.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	441	n/a
-2	10.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	701	n/a
-3	12.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	469	n/a
-4	15.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	499	n/a
-5	17.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	467	n/a
-6	25.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	823	n/a
-7	27.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	374	n/a
-8	30.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	502	n/a
-9	32.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	428	n/a
-10	35.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	499	n/a
-11	37.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	474	n/a
-12	40.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	577	n/a
-13	42.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	615	n/a
-14	45.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	422	n/a
-15	47.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	445	n/a
-16	50.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	468	n/a
-17	52.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	578	n/a
-18	60.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	871	n/a
-19	62.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	383	n/a
-20	65.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	485	n/a
-21	67.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	516	n/a
-22	75.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	520	n/a
-23	77.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	464	n/a
-24	80.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	438	n/a
-25	82.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	678	n/a
-26	85.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	468	n/a
-27	87.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	435	n/a
-28	90.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	458	n/a
-29	92.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	529	n/a
-30	95.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	527	n/a
-31	97.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	558	n/a
-32	100.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	477	n/a
-33	102.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	500	n/a
-34	105.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	499	n/a
-35	107.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	489	n/a
-36	110.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	465	n/a
-37	112.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	487	n/a
-38	120.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	692	n/a
-39	122.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	331	n/a
-40	125.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	346	n/a
-41	127.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	520	n/a
-42	130.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	416	n/a
-43	132.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	518	n/a
-44	135.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	389	n/a
-45	137.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	484	n/a
-46	140.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	459	n/a
-47	142.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	506	n/a
-48	150.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	678	n/a
-49	152.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	398	n/a
-50	155.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	516	n/a
-51	157.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	387	n/a
-52	160.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	393	n/a
-53	162.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	465	n/a
-54	165.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	415	n/a
-55	167.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	398	n/a
-56	170.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	478	n/a
-57	172.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	412	n/a
-58	175.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	507	n/a
-59	177.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	361	n/a
-60	185.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	702	n/a
-61	187.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	397	n/a
-62	190.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	356	n/a
-63	192.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	467	n/a
-64	195.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	514	n/a
-65	197.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	353	n/a
-66	200.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	471	n/a
-67	202.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	383	n/a
-68	210.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	587	n/a
-69	212.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	419	n/a
-70	215.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	449	n/a
-71	217.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	384	n/a
-72	225.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	692	n/a
-73	227.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	348	n/a
-74	230.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	394	n/a
-75	232.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	425	n/a
-76	235.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	505	n/a
-77	237.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	367	n/a
-78	240.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	542	n/a
-79	242.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
-80	245.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	460	n/a
-81	247.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	386	n/a
-82	250.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	401	n/a
-83	252.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	416	n/a
-84	260.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	565	n/a
-85	262.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	419	n/a
-86	270.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	512	n/a
-87	272.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	384	n/a
-88	275.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	750	n/a
-89	277.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	406	n/a
-90	285.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	634	n/a
-91	287.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	489	n/a
-92	290.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	840	n/a
-93	292.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	487	n/a
-94	295.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	533	n/a
-95	297.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	581	n/a
+onset	duration	trial_type	congruent_incorrect	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	754	n/a
+2.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	441	n/a
+10.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	701	n/a
+12.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	469	n/a
+15.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	499	n/a
+17.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	467	n/a
+25.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	823	n/a
+27.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	374	n/a
+30.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	502	n/a
+32.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	428	n/a
+35.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	499	n/a
+37.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	474	n/a
+40.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	577	n/a
+42.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	615	n/a
+45.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	422	n/a
+47.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	445	n/a
+50.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	468	n/a
+52.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	578	n/a
+60.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	871	n/a
+62.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	383	n/a
+65.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	485	n/a
+67.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	516	n/a
+75.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	520	n/a
+77.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	464	n/a
+80.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	438	n/a
+82.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	678	n/a
+85.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	468	n/a
+87.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	435	n/a
+90.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	458	n/a
+92.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	529	n/a
+95.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	527	n/a
+97.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	558	n/a
+100.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	477	n/a
+102.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	500	n/a
+105.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	499	n/a
+107.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	489	n/a
+110.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	465	n/a
+112.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	487	n/a
+120.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	692	n/a
+122.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	331	n/a
+125.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	346	n/a
+127.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	520	n/a
+130.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	416	n/a
+132.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	518	n/a
+135.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	389	n/a
+137.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	484	n/a
+140.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	459	n/a
+142.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	506	n/a
+150.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	678	n/a
+152.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	398	n/a
+155.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	516	n/a
+157.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	387	n/a
+160.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	393	n/a
+162.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	465	n/a
+165.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	415	n/a
+167.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	398	n/a
+170.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	478	n/a
+172.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	412	n/a
+175.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	507	n/a
+177.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	361	n/a
+185.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	702	n/a
+187.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	397	n/a
+190.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	356	n/a
+192.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	467	n/a
+195.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	514	n/a
+197.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	353	n/a
+200.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	471	n/a
+202.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	383	n/a
+210.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	587	n/a
+212.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	419	n/a
+215.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	449	n/a
+217.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	384	n/a
+225.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	692	n/a
+227.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	348	n/a
+230.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	394	n/a
+232.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	425	n/a
+235.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	505	n/a
+237.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	367	n/a
+240.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	542	n/a
+242.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
+245.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	460	n/a
+247.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	386	n/a
+250.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	401	n/a
+252.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	416	n/a
+260.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	565	n/a
+262.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	419	n/a
+270.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	512	n/a
+272.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	384	n/a
+275.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	750	n/a
+277.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	406	n/a
+285.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	634	n/a
+287.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	489	n/a
+290.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	840	n/a
+292.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	487	n/a
+295.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	533	n/a
+297.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	581	n/a

--- a/ds101/sub-15/func/sub-15_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-15/func/sub-15_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	1	2	incongruent	500	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	492	n/a
-2	5.0	1.0	congruent_correct	n/a	1	1	congruent	498	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	441	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	560	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	535	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	683	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	587	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	442	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	736	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	526	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	576	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	543	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	630	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	508	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	698	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	863	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	607	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	572	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	530	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	488	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	511	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
-27	87.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	539	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	530	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	656	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	685	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	507	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	598	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	548	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	591	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	447	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	572	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	611	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	546	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	527	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	534	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	589	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	706	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	959	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	629	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	596	n/a
-58	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	569	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	526	n/a
-62	195.0	1.0	congruent_incorrect	n/a	0	1	congruent	508	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	668	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	666	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	633	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	599	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	535	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	683	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	658	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	617	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	712	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	598	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	533	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	467	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	538	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	577	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	600	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	614	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	445	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	708	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	555	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	560	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	575	n/a
-86	270.0	1.0	incongruent_correct	n/a	1	2	incongruent	641	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	497	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	447	n/a
-89	277.5	1.0	incongruent_correct	n/a	1	2	incongruent	575	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	685	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	444	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	848	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	573	n/a
+onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	1	2	incongruent	500	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	492	n/a
+5.0	1.0	congruent_correct	n/a	1	1	congruent	498	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	441	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	560	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	535	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	683	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	587	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	442	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	736	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	495	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	526	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	576	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	543	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	630	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	508	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	698	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	863	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	607	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	572	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	451	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	530	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	488	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	511	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
+87.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	539	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	546	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	530	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	656	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	685	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	507	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	505	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	598	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	548	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	591	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	447	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	572	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	611	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	546	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	527	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	534	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	589	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	706	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	959	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	629	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	596	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	569	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	526	n/a
+195.0	1.0	congruent_incorrect	n/a	0	1	congruent	508	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	668	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	666	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	633	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	599	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	535	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	683	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	658	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	617	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	712	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	598	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	533	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	467	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	538	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	577	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	600	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	614	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	445	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	708	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	555	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	560	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	575	n/a
+270.0	1.0	incongruent_correct	n/a	1	2	incongruent	641	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	497	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	447	n/a
+277.5	1.0	incongruent_correct	n/a	1	2	incongruent	575	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	685	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	444	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	848	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	464	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	573	n/a

--- a/ds101/sub-15/func/sub-15_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-15/func/sub-15_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	786	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	672	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	576	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	579	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	770	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	552	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	718	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	577	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	527	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	722	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	472	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	443	n/a
-25	82.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	385	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	904	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	575	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	638	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	660	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	651	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	512	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	590	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	660	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	627	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	687	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	591	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	565	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	739	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	690	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	601	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	608	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	407	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	537	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	552	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	678	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	574	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	652	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	515	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	585	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	536	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	790	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	438	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	650	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	513	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	501	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	532	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	690	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	599	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	499	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	616	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	439	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	606	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
-76	235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	412	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	603	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	473	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	625	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	614	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	597	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	812	n/a
-84	260.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	472	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	757	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	691	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	635	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	590	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	653	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	652	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	594	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	592	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	786	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	672	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	576	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	579	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	770	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	552	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	718	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	577	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	527	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	722	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	472	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	443	n/a
+82.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	385	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	904	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	575	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	638	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	660	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	651	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	512	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	590	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	660	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	627	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	687	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	591	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	565	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	739	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	690	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	601	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	608	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	407	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	557	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	537	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	552	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	678	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	574	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	652	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	515	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	585	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	536	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	790	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	438	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	650	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	513	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	501	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	532	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	690	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	599	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	499	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	616	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	439	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	606	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
+235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	412	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	603	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	473	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	625	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	559	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	614	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	597	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	812	n/a
+260.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	472	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	757	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	691	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	635	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	465	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	590	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	653	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	652	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	594	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	602	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	592	n/a

--- a/ds101/sub-16/func/sub-16_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-16/func/sub-16_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	1	2	incongruent	632	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
-2	5.0	1.0	congruent_correct	n/a	1	1	congruent	510	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	516	n/a
-4	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	498	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	855	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	350	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	573	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	380	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	426	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	457	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	611	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	531	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	512	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	438	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	651	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	431	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	591	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	964	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	378	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	530	n/a
-27	87.5	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	389	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	354	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	633	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	477	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	407	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	409	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	375	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
-48	150.0	1.0	congruent_incorrect	n/a	0	1	congruent	444	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	450	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	494	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	754	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	498	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	472	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
-58	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	620	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	427	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	585	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	472	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	551	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	510	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	451	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	386	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	631	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	429	n/a
-70	220.0	1.0	congruent_incorrect	n/a	0	1	congruent	501	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	504	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	600	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	591	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	605	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	477	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	515	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	626	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
-81	247.5	1.0	incongruent_correct	n/a	1	2	incongruent	504	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	566	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	515	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	491	n/a
-86	270.0	1.0	incongruent_correct	n/a	1	2	incongruent	749	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	564	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	539	n/a
-89	277.5	1.0	incongruent_correct	n/a	1	2	incongruent	674	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	529	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	631	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	924	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	386	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	832	n/a
+onset	duration	trial_type	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	1	2	incongruent	632	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
+5.0	1.0	congruent_correct	n/a	1	1	congruent	510	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	516	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	498	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	855	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	350	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	573	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	380	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	426	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	457	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	611	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	531	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	545	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	512	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	438	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	651	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	490	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	513	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	431	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	591	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	453	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	964	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	378	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	530	n/a
+87.5	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	389	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	354	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	633	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	479	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	477	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	549	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	408	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	407	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	366	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	409	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	375	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	437	n/a
+150.0	1.0	congruent_incorrect	n/a	0	1	congruent	444	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	450	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	441	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	471	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	494	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	754	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	498	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	472	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	472	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	620	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	427	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	482	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	585	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	472	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	551	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	510	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	451	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	386	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	631	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	429	n/a
+220.0	1.0	congruent_incorrect	n/a	0	1	congruent	501	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	474	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	504	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	600	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	591	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	605	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	477	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	515	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	626	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	528	n/a
+247.5	1.0	incongruent_correct	n/a	1	2	incongruent	504	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	566	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	517	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	515	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	491	n/a
+270.0	1.0	incongruent_correct	n/a	1	2	incongruent	749	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	564	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	539	n/a
+277.5	1.0	incongruent_correct	n/a	1	2	incongruent	674	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	529	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	631	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	924	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	547	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	386	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	832	n/a

--- a/ds101/sub-16/func/sub-16_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-16/func/sub-16_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	788	n/a
-1	2.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	451	n/a
-2	10.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	823	n/a
-3	12.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	407	n/a
-4	15.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	549	n/a
-5	17.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
-6	25.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	825	n/a
-7	27.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	456	n/a
-8	30.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	424	n/a
-9	32.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	558	n/a
-10	35.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	477	n/a
-11	37.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	419	n/a
-12	40.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	395	n/a
-13	42.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	449	n/a
-14	45.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	456	n/a
-15	47.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	502	n/a
-16	50.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	406	n/a
-17	52.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	436	n/a
-18	60.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	585	n/a
-19	62.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	424	n/a
-20	65.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	431	n/a
-21	67.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	366	n/a
-22	75.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	578	n/a
-23	77.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	370	n/a
-24	80.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	520	n/a
-25	82.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	568	n/a
-26	85.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	446	n/a
-27	87.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	517	n/a
-28	90.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	491	n/a
-29	92.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	515	n/a
-30	95.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	537	n/a
-31	97.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	496	n/a
-32	100.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	647	n/a
-33	102.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	518	n/a
-34	105.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	429	n/a
-35	107.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	531	n/a
-36	110.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	507	n/a
-37	112.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	513	n/a
-38	120.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	598	n/a
-39	122.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	389	n/a
-40	125.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	628	n/a
-41	127.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	354	n/a
-42	130.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	417	n/a
-43	132.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	624	n/a
-44	135.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	479	n/a
-45	137.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	518	n/a
-46	140.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	500	n/a
-47	142.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	468	n/a
-48	150.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	560	n/a
-49	152.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	624	n/a
-50	155.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	518	n/a
-51	157.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	469	n/a
-52	160.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	459	n/a
-53	162.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	395	n/a
-54	165.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	481	n/a
-55	167.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	392	n/a
-56	170.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	431	n/a
-57	172.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	446	n/a
-58	175.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	589	n/a
-59	177.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	411	n/a
-60	185.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	528	n/a
-61	187.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	487	n/a
-62	190.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	470	n/a
-63	192.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	542	n/a
-64	195.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	468	n/a
-65	197.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	386	n/a
-66	200.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	449	n/a
-67	202.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	513	n/a
-68	210.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	613	n/a
-69	212.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	364	n/a
-70	215.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	811	n/a
-71	217.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	442	n/a
-72	225.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	486	n/a
-73	227.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	406	n/a
-74	230.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	492	n/a
-75	232.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	379	n/a
-76	235.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	467	n/a
-77	237.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	433	n/a
-78	240.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	408	n/a
-79	242.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	414	n/a
-80	245.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	390	n/a
-81	247.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	508	n/a
-82	250.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	499	n/a
-83	252.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	433	n/a
-84	260.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	526	n/a
-85	262.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	445	n/a
-86	270.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	514	n/a
-87	272.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	418	n/a
-88	275.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	480	n/a
-89	277.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	472	n/a
-90	285.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	772	n/a
-91	287.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	443	n/a
-92	290.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	602	n/a
-93	292.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	441	n/a
-94	295.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	847	n/a
-95	297.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	374	n/a
+onset	duration	trial_type	congruent_incorrect	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	788	n/a
+2.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	451	n/a
+10.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	823	n/a
+12.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	407	n/a
+15.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	549	n/a
+17.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
+25.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	825	n/a
+27.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	456	n/a
+30.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	424	n/a
+32.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	558	n/a
+35.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	477	n/a
+37.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	419	n/a
+40.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	395	n/a
+42.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	449	n/a
+45.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	456	n/a
+47.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	502	n/a
+50.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	406	n/a
+52.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	436	n/a
+60.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	585	n/a
+62.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	424	n/a
+65.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	431	n/a
+67.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	366	n/a
+75.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	578	n/a
+77.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	370	n/a
+80.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	520	n/a
+82.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	568	n/a
+85.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	446	n/a
+87.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	517	n/a
+90.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	491	n/a
+92.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	515	n/a
+95.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	537	n/a
+97.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	496	n/a
+100.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	647	n/a
+102.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	518	n/a
+105.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	429	n/a
+107.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	531	n/a
+110.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	507	n/a
+112.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	513	n/a
+120.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	598	n/a
+122.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	389	n/a
+125.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	628	n/a
+127.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	354	n/a
+130.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	417	n/a
+132.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	624	n/a
+135.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	479	n/a
+137.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	518	n/a
+140.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	500	n/a
+142.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	468	n/a
+150.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	560	n/a
+152.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	624	n/a
+155.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	518	n/a
+157.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	469	n/a
+160.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	459	n/a
+162.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	395	n/a
+165.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	481	n/a
+167.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	392	n/a
+170.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	431	n/a
+172.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	446	n/a
+175.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	589	n/a
+177.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	411	n/a
+185.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	528	n/a
+187.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	487	n/a
+190.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	470	n/a
+192.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	542	n/a
+195.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	468	n/a
+197.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	386	n/a
+200.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	449	n/a
+202.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	513	n/a
+210.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	613	n/a
+212.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	364	n/a
+215.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	811	n/a
+217.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	442	n/a
+225.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	486	n/a
+227.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	406	n/a
+230.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	492	n/a
+232.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	379	n/a
+235.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	467	n/a
+237.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	433	n/a
+240.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	408	n/a
+242.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	414	n/a
+245.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	390	n/a
+247.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	508	n/a
+250.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	499	n/a
+252.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	433	n/a
+260.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	526	n/a
+262.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	445	n/a
+270.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	514	n/a
+272.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	418	n/a
+275.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	480	n/a
+277.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	472	n/a
+285.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	772	n/a
+287.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	443	n/a
+290.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	602	n/a
+292.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	441	n/a
+295.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	847	n/a
+297.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	374	n/a

--- a/ds101/sub-17/func/sub-17_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-17/func/sub-17_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	514	n/a
-1	2.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	440	n/a
-2	5.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	432	n/a
-3	7.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	302	n/a
-4	10.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	413	n/a
-5	12.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
-6	20.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	432	n/a
-7	22.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	432	n/a
-8	25.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	414	n/a
-9	27.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	430	n/a
-10	30.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	460	n/a
-11	32.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	347	n/a
-12	45.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	414	n/a
-13	47.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	348	n/a
-14	50.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	356	n/a
-15	52.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	418	n/a
-16	55.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	425	n/a
-17	57.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	359	n/a
-18	65.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	372	n/a
-19	67.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	412	n/a
-20	70.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	410	n/a
-21	72.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	394	n/a
-22	75.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	392	n/a
-23	77.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	391	n/a
-24	80.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	461	n/a
-25	82.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	445	n/a
-26	85.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	420	n/a
-27	87.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	546	n/a
-28	90.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	377	n/a
-29	92.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	328	n/a
-30	95.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	391	n/a
-31	97.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	389	n/a
-32	100.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	388	n/a
-33	102.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	442	n/a
-34	105.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	482	n/a
-35	107.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	393	n/a
-36	110.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	351	n/a
-37	112.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	350	n/a
-38	120.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	651	n/a
-39	122.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	370	n/a
-40	125.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	360	n/a
-41	127.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	408	n/a
-42	135.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	421	n/a
-43	137.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	331	n/a
-44	140.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	363	n/a
-45	142.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	385	n/a
-46	145.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	392	n/a
-47	147.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	351	n/a
-48	150.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	430	n/a
-49	152.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	349	n/a
-50	155.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	387	n/a
-51	157.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	522	n/a
-52	160.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	401	n/a
-53	162.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	328	n/a
-54	170.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
-55	172.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	388	n/a
-56	175.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	371	n/a
-57	177.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	409	n/a
-58	185.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	414	n/a
-59	187.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	389	n/a
-60	190.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	436	n/a
-61	192.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	386	n/a
-62	195.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	442	n/a
-63	197.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	321	n/a
-64	200.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	415	n/a
-65	202.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	438	n/a
-66	205.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	429	n/a
-67	207.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	340	n/a
-68	215.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	520	n/a
-69	217.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	392	n/a
-70	220.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	351	n/a
-71	222.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	397	n/a
-72	225.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	380	n/a
-73	227.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	371	n/a
-74	230.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	394	n/a
-75	232.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	328	n/a
-76	235.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	463	n/a
-77	237.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	414	n/a
-78	240.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	397	n/a
-79	242.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	428	n/a
-80	245.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	426	n/a
-81	247.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	378	n/a
-82	250.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	408	n/a
-83	252.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	319	n/a
-84	255.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	437	n/a
-85	257.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	373	n/a
-86	270.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	527	n/a
-87	272.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	318	n/a
-88	275.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	357	n/a
-89	277.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	379	n/a
-90	280.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	451	n/a
-91	282.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	417	n/a
-92	290.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	398	n/a
-93	292.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	406	n/a
-94	295.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
-95	297.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	363	n/a
+onset	duration	trial_type	congruent_incorrect	incongruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	514	n/a
+2.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	440	n/a
+5.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	432	n/a
+7.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	302	n/a
+10.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	413	n/a
+12.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
+20.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	432	n/a
+22.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	432	n/a
+25.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	414	n/a
+27.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	430	n/a
+30.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	460	n/a
+32.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	347	n/a
+45.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	414	n/a
+47.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	348	n/a
+50.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	356	n/a
+52.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	418	n/a
+55.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	425	n/a
+57.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	359	n/a
+65.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	372	n/a
+67.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	412	n/a
+70.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	410	n/a
+72.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	394	n/a
+75.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	392	n/a
+77.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	391	n/a
+80.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	461	n/a
+82.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	445	n/a
+85.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	420	n/a
+87.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	546	n/a
+90.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	377	n/a
+92.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	328	n/a
+95.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	391	n/a
+97.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	389	n/a
+100.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	388	n/a
+102.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	442	n/a
+105.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	482	n/a
+107.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	393	n/a
+110.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	351	n/a
+112.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	350	n/a
+120.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	651	n/a
+122.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	370	n/a
+125.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	360	n/a
+127.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	408	n/a
+135.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	421	n/a
+137.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	331	n/a
+140.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	363	n/a
+142.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	385	n/a
+145.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	392	n/a
+147.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	351	n/a
+150.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	430	n/a
+152.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	349	n/a
+155.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	387	n/a
+157.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	522	n/a
+160.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	401	n/a
+162.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	328	n/a
+170.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
+172.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	388	n/a
+175.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	371	n/a
+177.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	409	n/a
+185.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	414	n/a
+187.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	389	n/a
+190.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	436	n/a
+192.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	386	n/a
+195.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	442	n/a
+197.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	321	n/a
+200.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	415	n/a
+202.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	438	n/a
+205.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	429	n/a
+207.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	340	n/a
+215.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	520	n/a
+217.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	392	n/a
+220.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	351	n/a
+222.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	397	n/a
+225.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	380	n/a
+227.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	371	n/a
+230.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	394	n/a
+232.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	328	n/a
+235.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	463	n/a
+237.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	414	n/a
+240.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	397	n/a
+242.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	428	n/a
+245.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	426	n/a
+247.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	378	n/a
+250.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	408	n/a
+252.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	319	n/a
+255.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	437	n/a
+257.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	373	n/a
+270.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	527	n/a
+272.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	318	n/a
+275.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	357	n/a
+277.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	379	n/a
+280.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	451	n/a
+282.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	417	n/a
+290.0	1.0	congruent_correct	n/a	n/a	1	1	congruent	398	n/a
+292.5	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	406	n/a
+295.0	1.0	incongruent_correct	n/a	n/a	1	2	incongruent	420	n/a
+297.5	1.0	congruent_correct	n/a	n/a	1	1	congruent	363	n/a

--- a/ds101/sub-17/func/sub-17_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-17/func/sub-17_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	437	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
-2	10.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	392	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	376	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	390	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	389	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	424	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	390	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	377	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	369	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	303	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	373	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	497	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	385	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	438	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	507	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	482	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	457	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	492	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	411	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	370	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	488	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	415	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	442	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	418	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	478	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	317	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	339	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	520	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	454	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	507	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	808	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	424	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	371	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	481	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	361	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	384	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	382	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	381	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	636	n/a
-60	185.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	617	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	415	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	404	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	530	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	457	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	461	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	453	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	428	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	551	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
-76	235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	419	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	362	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	511	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	437	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	342	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	635	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	487	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	476	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	626	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	722	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	776	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	437	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	363	n/a
+10.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	392	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	376	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	390	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	389	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	449	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	424	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	462	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	390	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	377	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	369	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	303	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	373	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	497	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	385	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	438	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	507	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	482	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	457	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	397	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	492	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	411	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	370	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	488	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	415	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	413	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	442	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	418	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	478	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	317	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	339	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	520	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	454	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	507	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	808	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	424	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	462	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	371	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	481	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	361	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	384	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	382	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	381	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	636	n/a
+185.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	617	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	431	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	415	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	478	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	404	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	483	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	530	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	457	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	461	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	453	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	428	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	418	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	551	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	406	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	349	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
+235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	419	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	362	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	400	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	511	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	437	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	466	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	342	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	635	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	487	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	476	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	626	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	722	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	776	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	479	n/a

--- a/ds101/sub-18/func/sub-18_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-18/func/sub-18_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	1	2	incongruent	595	n/a
-1	2.5	1.0	incongruent_correct	1	2	incongruent	433	n/a
-2	5.0	1.0	congruent_correct	1	1	congruent	353	n/a
-3	7.5	1.0	congruent_correct	1	1	congruent	319	n/a
-4	10.0	1.0	incongruent_correct	1	2	incongruent	398	n/a
-5	12.5	1.0	incongruent_correct	1	2	incongruent	349	n/a
-6	20.0	1.0	incongruent_correct	1	2	incongruent	537	n/a
-7	22.5	1.0	incongruent_correct	1	2	incongruent	385	n/a
-8	25.0	1.0	congruent_correct	1	1	congruent	503	n/a
-9	27.5	1.0	congruent_correct	1	1	congruent	551	n/a
-10	30.0	1.0	congruent_correct	1	1	congruent	389	n/a
-11	32.5	1.0	congruent_correct	1	1	congruent	324	n/a
-12	45.0	1.0	congruent_correct	1	1	congruent	655	n/a
-13	47.5	1.0	congruent_correct	1	1	congruent	365	n/a
-14	50.0	1.0	incongruent_correct	1	2	incongruent	517	n/a
-15	52.5	1.0	incongruent_correct	1	2	incongruent	371	n/a
-16	55.0	1.0	congruent_correct	1	1	congruent	410	n/a
-17	57.5	1.0	incongruent_correct	1	2	incongruent	360	n/a
-18	65.0	1.0	congruent_incorrect	0	1	congruent	493	n/a
-19	67.5	1.0	incongruent_correct	1	2	incongruent	438	n/a
-20	70.0	1.0	incongruent_correct	1	2	incongruent	387	n/a
-21	72.5	1.0	incongruent_correct	1	2	incongruent	403	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	377	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	376	n/a
-24	80.0	1.0	congruent_correct	1	1	congruent	359	n/a
-25	82.5	1.0	congruent_correct	1	1	congruent	342	n/a
-26	85.0	1.0	congruent_correct	1	1	congruent	317	n/a
-27	87.5	1.0	incongruent_incorrect	0	2	incongruent	323	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	370	n/a
-29	92.5	1.0	congruent_correct	1	1	congruent	489	n/a
-30	95.0	1.0	incongruent_correct	1	2	incongruent	416	n/a
-31	97.5	1.0	incongruent_correct	1	2	incongruent	430	n/a
-32	100.0	1.0	incongruent_correct	1	2	incongruent	357	n/a
-33	102.5	1.0	incongruent_correct	1	2	incongruent	333	n/a
-34	105.0	1.0	congruent_correct	1	1	congruent	371	n/a
-35	107.5	1.0	congruent_correct	1	1	congruent	354	n/a
-36	110.0	1.0	incongruent_correct	1	2	incongruent	416	n/a
-37	112.5	1.0	incongruent_correct	1	2	incongruent	408	n/a
-38	120.0	1.0	incongruent_correct	1	2	incongruent	484	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	371	n/a
-40	125.0	1.0	congruent_correct	1	1	congruent	362	n/a
-41	127.5	1.0	congruent_correct	1	1	congruent	377	n/a
-42	135.0	1.0	incongruent_correct	1	2	incongruent	566	n/a
-43	137.5	1.0	congruent_correct	1	1	congruent	405	n/a
-44	140.0	1.0	congruent_correct	1	1	congruent	420	n/a
-45	142.5	1.0	incongruent_correct	1	2	incongruent	466	n/a
-46	145.0	1.0	congruent_correct	1	1	congruent	353	n/a
-47	147.5	1.0	incongruent_incorrect	0	2	incongruent	337	n/a
-48	150.0	1.0	congruent_correct	1	1	congruent	439	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	358	n/a
-50	155.0	1.0	congruent_correct	1	1	congruent	372	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	436	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	354	n/a
-53	162.5	1.0	congruent_correct	1	1	congruent	409	n/a
-54	170.0	1.0	incongruent_correct	1	2	incongruent	525	n/a
-55	172.5	1.0	congruent_correct	1	1	congruent	357	n/a
-56	175.0	1.0	congruent_correct	1	1	congruent	356	n/a
-57	177.5	1.0	incongruent_correct	1	2	incongruent	418	n/a
-58	185.0	1.0	incongruent_correct	1	2	incongruent	567	n/a
-59	187.5	1.0	incongruent_correct	1	2	incongruent	478	n/a
-60	190.0	1.0	incongruent_correct	1	2	incongruent	405	n/a
-61	192.5	1.0	incongruent_correct	1	2	incongruent	412	n/a
-62	195.0	1.0	congruent_correct	1	1	congruent	427	n/a
-63	197.5	1.0	congruent_correct	1	1	congruent	434	n/a
-64	200.0	1.0	congruent_correct	1	1	congruent	360	n/a
-65	202.5	1.0	incongruent_correct	1	2	incongruent	448	n/a
-66	205.0	1.0	incongruent_correct	1	2	incongruent	406	n/a
-67	207.5	1.0	incongruent_correct	1	2	incongruent	389	n/a
-68	215.0	1.0	incongruent_correct	1	2	incongruent	449	n/a
-69	217.5	1.0	incongruent_correct	1	2	incongruent	337	n/a
-70	220.0	1.0	congruent_correct	1	1	congruent	400	n/a
-71	222.5	1.0	incongruent_correct	1	2	incongruent	478	n/a
-72	225.0	1.0	incongruent_correct	1	2	incongruent	422	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	420	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	347	n/a
-75	232.5	1.0	congruent_correct	1	1	congruent	385	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	625	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	375	n/a
-78	240.0	1.0	incongruent_correct	1	2	incongruent	398	n/a
-79	242.5	1.0	congruent_correct	1	1	congruent	365	n/a
-80	245.0	1.0	congruent_correct	1	1	congruent	363	n/a
-81	247.5	1.0	incongruent_correct	1	2	incongruent	403	n/a
-82	250.0	1.0	congruent_correct	1	1	congruent	393	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	376	n/a
-84	255.0	1.0	incongruent_correct	1	2	incongruent	470	n/a
-85	257.5	1.0	congruent_correct	1	1	congruent	414	n/a
-86	270.0	1.0	incongruent_correct	1	2	incongruent	520	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	375	n/a
-88	275.0	1.0	congruent_correct	1	1	congruent	390	n/a
-89	277.5	1.0	incongruent_correct	1	2	incongruent	477	n/a
-90	280.0	1.0	incongruent_correct	1	2	incongruent	468	n/a
-91	282.5	1.0	congruent_correct	1	1	congruent	386	n/a
-92	290.0	1.0	congruent_correct	1	1	congruent	519	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	431	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	397	n/a
-95	297.5	1.0	congruent_correct	1	1	congruent	356	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	1	2	incongruent	595	n/a
+2.5	1.0	incongruent_correct	1	2	incongruent	433	n/a
+5.0	1.0	congruent_correct	1	1	congruent	353	n/a
+7.5	1.0	congruent_correct	1	1	congruent	319	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	398	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	349	n/a
+20.0	1.0	incongruent_correct	1	2	incongruent	537	n/a
+22.5	1.0	incongruent_correct	1	2	incongruent	385	n/a
+25.0	1.0	congruent_correct	1	1	congruent	503	n/a
+27.5	1.0	congruent_correct	1	1	congruent	551	n/a
+30.0	1.0	congruent_correct	1	1	congruent	389	n/a
+32.5	1.0	congruent_correct	1	1	congruent	324	n/a
+45.0	1.0	congruent_correct	1	1	congruent	655	n/a
+47.5	1.0	congruent_correct	1	1	congruent	365	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	517	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	371	n/a
+55.0	1.0	congruent_correct	1	1	congruent	410	n/a
+57.5	1.0	incongruent_correct	1	2	incongruent	360	n/a
+65.0	1.0	congruent_incorrect	0	1	congruent	493	n/a
+67.5	1.0	incongruent_correct	1	2	incongruent	438	n/a
+70.0	1.0	incongruent_correct	1	2	incongruent	387	n/a
+72.5	1.0	incongruent_correct	1	2	incongruent	403	n/a
+75.0	1.0	congruent_correct	1	1	congruent	377	n/a
+77.5	1.0	congruent_correct	1	1	congruent	376	n/a
+80.0	1.0	congruent_correct	1	1	congruent	359	n/a
+82.5	1.0	congruent_correct	1	1	congruent	342	n/a
+85.0	1.0	congruent_correct	1	1	congruent	317	n/a
+87.5	1.0	incongruent_incorrect	0	2	incongruent	323	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	370	n/a
+92.5	1.0	congruent_correct	1	1	congruent	489	n/a
+95.0	1.0	incongruent_correct	1	2	incongruent	416	n/a
+97.5	1.0	incongruent_correct	1	2	incongruent	430	n/a
+100.0	1.0	incongruent_correct	1	2	incongruent	357	n/a
+102.5	1.0	incongruent_correct	1	2	incongruent	333	n/a
+105.0	1.0	congruent_correct	1	1	congruent	371	n/a
+107.5	1.0	congruent_correct	1	1	congruent	354	n/a
+110.0	1.0	incongruent_correct	1	2	incongruent	416	n/a
+112.5	1.0	incongruent_correct	1	2	incongruent	408	n/a
+120.0	1.0	incongruent_correct	1	2	incongruent	484	n/a
+122.5	1.0	congruent_correct	1	1	congruent	371	n/a
+125.0	1.0	congruent_correct	1	1	congruent	362	n/a
+127.5	1.0	congruent_correct	1	1	congruent	377	n/a
+135.0	1.0	incongruent_correct	1	2	incongruent	566	n/a
+137.5	1.0	congruent_correct	1	1	congruent	405	n/a
+140.0	1.0	congruent_correct	1	1	congruent	420	n/a
+142.5	1.0	incongruent_correct	1	2	incongruent	466	n/a
+145.0	1.0	congruent_correct	1	1	congruent	353	n/a
+147.5	1.0	incongruent_incorrect	0	2	incongruent	337	n/a
+150.0	1.0	congruent_correct	1	1	congruent	439	n/a
+152.5	1.0	congruent_correct	1	1	congruent	358	n/a
+155.0	1.0	congruent_correct	1	1	congruent	372	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	436	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	354	n/a
+162.5	1.0	congruent_correct	1	1	congruent	409	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	525	n/a
+172.5	1.0	congruent_correct	1	1	congruent	357	n/a
+175.0	1.0	congruent_correct	1	1	congruent	356	n/a
+177.5	1.0	incongruent_correct	1	2	incongruent	418	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	567	n/a
+187.5	1.0	incongruent_correct	1	2	incongruent	478	n/a
+190.0	1.0	incongruent_correct	1	2	incongruent	405	n/a
+192.5	1.0	incongruent_correct	1	2	incongruent	412	n/a
+195.0	1.0	congruent_correct	1	1	congruent	427	n/a
+197.5	1.0	congruent_correct	1	1	congruent	434	n/a
+200.0	1.0	congruent_correct	1	1	congruent	360	n/a
+202.5	1.0	incongruent_correct	1	2	incongruent	448	n/a
+205.0	1.0	incongruent_correct	1	2	incongruent	406	n/a
+207.5	1.0	incongruent_correct	1	2	incongruent	389	n/a
+215.0	1.0	incongruent_correct	1	2	incongruent	449	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	337	n/a
+220.0	1.0	congruent_correct	1	1	congruent	400	n/a
+222.5	1.0	incongruent_correct	1	2	incongruent	478	n/a
+225.0	1.0	incongruent_correct	1	2	incongruent	422	n/a
+227.5	1.0	congruent_correct	1	1	congruent	420	n/a
+230.0	1.0	congruent_correct	1	1	congruent	347	n/a
+232.5	1.0	congruent_correct	1	1	congruent	385	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	625	n/a
+237.5	1.0	congruent_correct	1	1	congruent	375	n/a
+240.0	1.0	incongruent_correct	1	2	incongruent	398	n/a
+242.5	1.0	congruent_correct	1	1	congruent	365	n/a
+245.0	1.0	congruent_correct	1	1	congruent	363	n/a
+247.5	1.0	incongruent_correct	1	2	incongruent	403	n/a
+250.0	1.0	congruent_correct	1	1	congruent	393	n/a
+252.5	1.0	congruent_correct	1	1	congruent	376	n/a
+255.0	1.0	incongruent_correct	1	2	incongruent	470	n/a
+257.5	1.0	congruent_correct	1	1	congruent	414	n/a
+270.0	1.0	incongruent_correct	1	2	incongruent	520	n/a
+272.5	1.0	congruent_correct	1	1	congruent	375	n/a
+275.0	1.0	congruent_correct	1	1	congruent	390	n/a
+277.5	1.0	incongruent_correct	1	2	incongruent	477	n/a
+280.0	1.0	incongruent_correct	1	2	incongruent	468	n/a
+282.5	1.0	congruent_correct	1	1	congruent	386	n/a
+290.0	1.0	congruent_correct	1	1	congruent	519	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	431	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	397	n/a
+297.5	1.0	congruent_correct	1	1	congruent	356	n/a

--- a/ds101/sub-18/func/sub-18_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-18/func/sub-18_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	603	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	323	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	527	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	374	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	316	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	481	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	336	n/a
-8	30.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	335	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	381	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	347	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	362	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	400	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	359	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	383	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	500	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	608	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	344	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	526	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	328	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	399	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	406	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	372	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-31	97.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	352	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	470	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	436	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	339	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	329	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	510	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	324	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	412	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	362	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	551	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	335	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	455	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	341	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	396	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	409	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	391	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	485	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	372	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
-60	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	536	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	327	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	339	n/a
-65	197.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	330	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	408	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	520	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	541	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	387	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	371	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	457	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	766	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	357	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	347	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	473	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	369	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	343	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	500	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	434	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	457	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	534	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	570	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	361	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	408	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	806	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	539	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	345	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	393	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	391	n/a
-95	297.5	1.0	incongruent_correct	n/a	1	2	incongruent	374	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	603	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	323	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	527	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	374	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	316	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	481	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	336	n/a
+30.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	335	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	381	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	460	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	347	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	362	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	400	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	359	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	383	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	500	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	608	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	344	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	526	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	458	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	328	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	399	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	406	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	372	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	411	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	387	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+97.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	352	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	414	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	470	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	436	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	339	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	329	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	510	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	324	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	412	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	362	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	551	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	335	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	455	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	341	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	396	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	426	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	409	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	391	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	407	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	485	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	372	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	386	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	536	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	327	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	413	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	381	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	339	n/a
+197.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	330	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	408	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	520	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	541	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	387	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	371	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	457	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	766	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	357	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	364	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	347	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	473	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	369	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	343	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	414	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	420	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	500	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	434	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	457	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	534	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	421	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	570	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	361	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	408	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	806	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	539	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	403	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	345	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	393	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	391	n/a
+297.5	1.0	incongruent_correct	n/a	1	2	incongruent	374	n/a

--- a/ds101/sub-19/func/sub-19_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-19/func/sub-19_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	1	2	incongruent	559	n/a
-1	2.5	1.0	incongruent_correct	1	2	incongruent	487	n/a
-2	5.0	1.0	congruent_correct	1	1	congruent	725	n/a
-3	7.5	1.0	congruent_correct	1	1	congruent	715	n/a
-4	10.0	1.0	incongruent_correct	1	2	incongruent	594	n/a
-5	12.5	1.0	incongruent_correct	1	2	incongruent	650	n/a
-6	20.0	1.0	incongruent_correct	1	2	incongruent	942	n/a
-7	22.5	1.0	incongruent_correct	1	2	incongruent	597	n/a
-8	25.0	1.0	congruent_correct	1	1	congruent	868	n/a
-9	27.5	1.0	congruent_correct	1	1	congruent	691	n/a
-10	30.0	1.0	congruent_correct	1	1	congruent	1065	n/a
-11	32.5	1.0	congruent_correct	1	1	congruent	864	n/a
-12	45.0	1.0	congruent_correct	1	1	congruent	1059	n/a
-13	47.5	1.0	congruent_correct	1	1	congruent	570	n/a
-14	50.0	1.0	incongruent_correct	1	2	incongruent	761	n/a
-15	52.5	1.0	incongruent_correct	1	2	incongruent	639	n/a
-16	55.0	1.0	congruent_correct	1	1	congruent	718	n/a
-17	57.5	1.0	incongruent_correct	1	2	incongruent	461	n/a
-18	65.0	1.0	congruent_correct	1	1	congruent	786	n/a
-19	67.5	1.0	incongruent_correct	1	2	incongruent	713	n/a
-20	70.0	1.0	incongruent_correct	1	2	incongruent	599	n/a
-21	72.5	1.0	incongruent_correct	1	2	incongruent	551	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	1341	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	492	n/a
-24	80.0	1.0	congruent_correct	1	1	congruent	563	n/a
-25	82.5	1.0	congruent_correct	1	1	congruent	426	n/a
-26	85.0	1.0	congruent_correct	1	1	congruent	441	n/a
-27	87.5	1.0	incongruent_correct	1	2	incongruent	727	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	590	n/a
-29	92.5	1.0	congruent_incorrect	0	1	congruent	693	n/a
-30	95.0	1.0	incongruent_correct	1	2	incongruent	924	n/a
-31	97.5	1.0	incongruent_correct	1	2	incongruent	754	n/a
-32	100.0	1.0	incongruent_correct	1	2	incongruent	617	n/a
-33	102.5	1.0	incongruent_incorrect	0	2	incongruent	0	n/a
-34	105.0	1.0	congruent_correct	1	1	congruent	1143	n/a
-35	107.5	1.0	congruent_correct	1	1	congruent	1014	n/a
-36	110.0	1.0	incongruent_correct	1	2	incongruent	908	n/a
-37	112.5	1.0	incongruent_correct	1	2	incongruent	756	n/a
-38	120.0	1.0	incongruent_correct	1	2	incongruent	1592	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	623	n/a
-40	125.0	1.0	congruent_incorrect	0	1	congruent	967	n/a
-41	127.5	1.0	congruent_incorrect	0	1	congruent	917	n/a
-42	135.0	1.0	incongruent_correct	1	2	incongruent	1122	n/a
-43	137.5	1.0	congruent_correct	1	1	congruent	641	n/a
-44	140.0	1.0	congruent_correct	1	1	congruent	456	n/a
-45	142.5	1.0	incongruent_incorrect	0	2	incongruent	902	n/a
-46	145.0	1.0	congruent_correct	1	1	congruent	605	n/a
-47	147.5	1.0	incongruent_correct	1	2	incongruent	557	n/a
-48	150.0	1.0	congruent_correct	1	1	congruent	835	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	522	n/a
-50	155.0	1.0	congruent_correct	1	1	congruent	464	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	560	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	622	n/a
-53	162.5	1.0	congruent_incorrect	0	1	congruent	549	n/a
-54	170.0	1.0	incongruent_correct	1	2	incongruent	1010	n/a
-55	172.5	1.0	congruent_correct	1	1	congruent	905	n/a
-56	175.0	1.0	congruent_correct	1	1	congruent	720	n/a
-57	177.5	1.0	incongruent_correct	1	2	incongruent	622	n/a
-58	185.0	1.0	incongruent_correct	1	2	incongruent	1155	n/a
-59	187.5	1.0	incongruent_correct	1	2	incongruent	834	n/a
-60	190.0	1.0	incongruent_correct	1	2	incongruent	585	n/a
-61	192.5	1.0	incongruent_correct	1	2	incongruent	768	n/a
-62	195.0	1.0	congruent_correct	1	1	congruent	663	n/a
-63	197.5	1.0	congruent_correct	1	1	congruent	614	n/a
-64	200.0	1.0	congruent_correct	1	1	congruent	516	n/a
-65	202.5	1.0	incongruent_correct	1	2	incongruent	563	n/a
-66	205.0	1.0	incongruent_correct	1	2	incongruent	562	n/a
-67	207.5	1.0	incongruent_correct	1	2	incongruent	785	n/a
-68	215.0	1.0	incongruent_correct	1	2	incongruent	662	n/a
-69	217.5	1.0	incongruent_correct	1	2	incongruent	701	n/a
-70	220.0	1.0	congruent_correct	1	1	congruent	540	n/a
-71	222.5	1.0	incongruent_correct	1	2	incongruent	610	n/a
-72	225.0	1.0	incongruent_correct	1	2	incongruent	753	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	624	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	727	n/a
-75	232.5	1.0	congruent_correct	1	1	congruent	414	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	612	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	971	n/a
-78	240.0	1.0	incongruent_correct	1	2	incongruent	642	n/a
-79	242.5	1.0	congruent_correct	1	1	congruent	505	n/a
-80	245.0	1.0	congruent_correct	1	1	congruent	487	n/a
-81	247.5	1.0	incongruent_correct	1	2	incongruent	967	n/a
-82	250.0	1.0	congruent_correct	1	1	congruent	701	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	748	n/a
-84	255.0	1.0	incongruent_correct	1	2	incongruent	1018	n/a
-85	257.5	1.0	congruent_correct	1	1	congruent	834	n/a
-86	270.0	1.0	incongruent_correct	1	2	incongruent	924	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	659	n/a
-88	275.0	1.0	congruent_correct	1	1	congruent	554	n/a
-89	277.5	1.0	incongruent_incorrect	0	2	incongruent	424	n/a
-90	280.0	1.0	incongruent_correct	1	2	incongruent	663	n/a
-91	282.5	1.0	congruent_correct	1	1	congruent	583	n/a
-92	290.0	1.0	congruent_correct	1	1	congruent	995	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	570	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	633	n/a
-95	297.5	1.0	congruent_correct	1	1	congruent	848	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	1	2	incongruent	559	n/a
+2.5	1.0	incongruent_correct	1	2	incongruent	487	n/a
+5.0	1.0	congruent_correct	1	1	congruent	725	n/a
+7.5	1.0	congruent_correct	1	1	congruent	715	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	594	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	650	n/a
+20.0	1.0	incongruent_correct	1	2	incongruent	942	n/a
+22.5	1.0	incongruent_correct	1	2	incongruent	597	n/a
+25.0	1.0	congruent_correct	1	1	congruent	868	n/a
+27.5	1.0	congruent_correct	1	1	congruent	691	n/a
+30.0	1.0	congruent_correct	1	1	congruent	1065	n/a
+32.5	1.0	congruent_correct	1	1	congruent	864	n/a
+45.0	1.0	congruent_correct	1	1	congruent	1059	n/a
+47.5	1.0	congruent_correct	1	1	congruent	570	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	761	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	639	n/a
+55.0	1.0	congruent_correct	1	1	congruent	718	n/a
+57.5	1.0	incongruent_correct	1	2	incongruent	461	n/a
+65.0	1.0	congruent_correct	1	1	congruent	786	n/a
+67.5	1.0	incongruent_correct	1	2	incongruent	713	n/a
+70.0	1.0	incongruent_correct	1	2	incongruent	599	n/a
+72.5	1.0	incongruent_correct	1	2	incongruent	551	n/a
+75.0	1.0	congruent_correct	1	1	congruent	1341	n/a
+77.5	1.0	congruent_correct	1	1	congruent	492	n/a
+80.0	1.0	congruent_correct	1	1	congruent	563	n/a
+82.5	1.0	congruent_correct	1	1	congruent	426	n/a
+85.0	1.0	congruent_correct	1	1	congruent	441	n/a
+87.5	1.0	incongruent_correct	1	2	incongruent	727	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	590	n/a
+92.5	1.0	congruent_incorrect	0	1	congruent	693	n/a
+95.0	1.0	incongruent_correct	1	2	incongruent	924	n/a
+97.5	1.0	incongruent_correct	1	2	incongruent	754	n/a
+100.0	1.0	incongruent_correct	1	2	incongruent	617	n/a
+102.5	1.0	incongruent_incorrect	0	2	incongruent	0	n/a
+105.0	1.0	congruent_correct	1	1	congruent	1143	n/a
+107.5	1.0	congruent_correct	1	1	congruent	1014	n/a
+110.0	1.0	incongruent_correct	1	2	incongruent	908	n/a
+112.5	1.0	incongruent_correct	1	2	incongruent	756	n/a
+120.0	1.0	incongruent_correct	1	2	incongruent	1592	n/a
+122.5	1.0	congruent_correct	1	1	congruent	623	n/a
+125.0	1.0	congruent_incorrect	0	1	congruent	967	n/a
+127.5	1.0	congruent_incorrect	0	1	congruent	917	n/a
+135.0	1.0	incongruent_correct	1	2	incongruent	1122	n/a
+137.5	1.0	congruent_correct	1	1	congruent	641	n/a
+140.0	1.0	congruent_correct	1	1	congruent	456	n/a
+142.5	1.0	incongruent_incorrect	0	2	incongruent	902	n/a
+145.0	1.0	congruent_correct	1	1	congruent	605	n/a
+147.5	1.0	incongruent_correct	1	2	incongruent	557	n/a
+150.0	1.0	congruent_correct	1	1	congruent	835	n/a
+152.5	1.0	congruent_correct	1	1	congruent	522	n/a
+155.0	1.0	congruent_correct	1	1	congruent	464	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	560	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	622	n/a
+162.5	1.0	congruent_incorrect	0	1	congruent	549	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	1010	n/a
+172.5	1.0	congruent_correct	1	1	congruent	905	n/a
+175.0	1.0	congruent_correct	1	1	congruent	720	n/a
+177.5	1.0	incongruent_correct	1	2	incongruent	622	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	1155	n/a
+187.5	1.0	incongruent_correct	1	2	incongruent	834	n/a
+190.0	1.0	incongruent_correct	1	2	incongruent	585	n/a
+192.5	1.0	incongruent_correct	1	2	incongruent	768	n/a
+195.0	1.0	congruent_correct	1	1	congruent	663	n/a
+197.5	1.0	congruent_correct	1	1	congruent	614	n/a
+200.0	1.0	congruent_correct	1	1	congruent	516	n/a
+202.5	1.0	incongruent_correct	1	2	incongruent	563	n/a
+205.0	1.0	incongruent_correct	1	2	incongruent	562	n/a
+207.5	1.0	incongruent_correct	1	2	incongruent	785	n/a
+215.0	1.0	incongruent_correct	1	2	incongruent	662	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	701	n/a
+220.0	1.0	congruent_correct	1	1	congruent	540	n/a
+222.5	1.0	incongruent_correct	1	2	incongruent	610	n/a
+225.0	1.0	incongruent_correct	1	2	incongruent	753	n/a
+227.5	1.0	congruent_correct	1	1	congruent	624	n/a
+230.0	1.0	congruent_correct	1	1	congruent	727	n/a
+232.5	1.0	congruent_correct	1	1	congruent	414	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	612	n/a
+237.5	1.0	congruent_correct	1	1	congruent	971	n/a
+240.0	1.0	incongruent_correct	1	2	incongruent	642	n/a
+242.5	1.0	congruent_correct	1	1	congruent	505	n/a
+245.0	1.0	congruent_correct	1	1	congruent	487	n/a
+247.5	1.0	incongruent_correct	1	2	incongruent	967	n/a
+250.0	1.0	congruent_correct	1	1	congruent	701	n/a
+252.5	1.0	congruent_correct	1	1	congruent	748	n/a
+255.0	1.0	incongruent_correct	1	2	incongruent	1018	n/a
+257.5	1.0	congruent_correct	1	1	congruent	834	n/a
+270.0	1.0	incongruent_correct	1	2	incongruent	924	n/a
+272.5	1.0	congruent_correct	1	1	congruent	659	n/a
+275.0	1.0	congruent_correct	1	1	congruent	554	n/a
+277.5	1.0	incongruent_incorrect	0	2	incongruent	424	n/a
+280.0	1.0	incongruent_correct	1	2	incongruent	663	n/a
+282.5	1.0	congruent_correct	1	1	congruent	583	n/a
+290.0	1.0	congruent_correct	1	1	congruent	995	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	570	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	633	n/a
+297.5	1.0	congruent_correct	1	1	congruent	848	n/a

--- a/ds101/sub-19/func/sub-19_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-19/func/sub-19_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	1	1	congruent	616	n/a
-1	2.5	1.0	congruent_correct	1	1	congruent	558	n/a
-2	10.0	1.0	incongruent_correct	1	2	incongruent	867	n/a
-3	12.5	1.0	incongruent_correct	1	2	incongruent	530	n/a
-4	15.0	1.0	incongruent_correct	1	2	incongruent	561	n/a
-5	17.5	1.0	incongruent_correct	1	2	incongruent	360	n/a
-6	25.0	1.0	congruent_correct	1	1	congruent	732	n/a
-7	27.5	1.0	congruent_correct	1	1	congruent	700	n/a
-8	30.0	1.0	incongruent_correct	1	2	incongruent	698	n/a
-9	32.5	1.0	congruent_correct	1	1	congruent	545	n/a
-10	35.0	1.0	incongruent_incorrect	0	2	incongruent	384	n/a
-11	37.5	1.0	congruent_correct	1	1	congruent	607	n/a
-12	40.0	1.0	congruent_correct	1	1	congruent	510	n/a
-13	42.5	1.0	incongruent_correct	1	2	incongruent	580	n/a
-14	45.0	1.0	incongruent_correct	1	2	incongruent	571	n/a
-15	47.5	1.0	incongruent_correct	1	2	incongruent	858	n/a
-16	50.0	1.0	incongruent_correct	1	2	incongruent	401	n/a
-17	52.5	1.0	incongruent_correct	1	2	incongruent	575	n/a
-18	60.0	1.0	congruent_correct	1	1	congruent	660	n/a
-19	62.5	1.0	congruent_correct	1	1	congruent	508	n/a
-20	65.0	1.0	congruent_correct	1	1	congruent	794	n/a
-21	67.5	1.0	congruent_correct	1	1	congruent	409	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	893	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	701	n/a
-24	80.0	1.0	congruent_correct	1	1	congruent	532	n/a
-25	82.5	1.0	incongruent_correct	1	2	incongruent	555	n/a
-26	85.0	1.0	incongruent_correct	1	2	incongruent	658	n/a
-27	87.5	1.0	congruent_correct	1	1	congruent	960	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	639	n/a
-29	92.5	1.0	congruent_incorrect	0	1	congruent	694	n/a
-30	95.0	1.0	congruent_correct	1	1	congruent	789	n/a
-31	97.5	1.0	incongruent_correct	1	2	incongruent	643	n/a
-32	100.0	1.0	congruent_correct	1	1	congruent	570	n/a
-33	102.5	1.0	incongruent_incorrect	0	2	incongruent	442	n/a
-34	105.0	1.0	incongruent_correct	1	2	incongruent	320	n/a
-35	107.5	1.0	incongruent_correct	1	2	incongruent	583	n/a
-36	110.0	1.0	congruent_correct	1	1	congruent	509	n/a
-37	112.5	1.0	congruent_correct	1	1	congruent	629	n/a
-38	120.0	1.0	congruent_correct	1	1	congruent	817	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	520	n/a
-40	125.0	1.0	congruent_correct	1	1	congruent	504	n/a
-41	127.5	1.0	congruent_correct	1	1	congruent	462	n/a
-42	130.0	1.0	congruent_correct	1	1	congruent	597	n/a
-43	132.5	1.0	incongruent_correct	1	2	incongruent	795	n/a
-44	135.0	1.0	congruent_correct	1	1	congruent	602	n/a
-45	137.5	1.0	incongruent_incorrect	0	2	incongruent	1017	n/a
-46	140.0	1.0	congruent_correct	1	1	congruent	832	n/a
-47	142.5	1.0	incongruent_correct	1	2	incongruent	1014	n/a
-48	150.0	1.0	incongruent_correct	1	2	incongruent	899	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	539	n/a
-50	155.0	1.0	incongruent_correct	1	2	incongruent	569	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	576	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	615	n/a
-53	162.5	1.0	incongruent_correct	1	2	incongruent	606	n/a
-54	165.0	1.0	incongruent_correct	1	2	incongruent	573	n/a
-55	167.5	1.0	incongruent_correct	1	2	incongruent	675	n/a
-56	170.0	1.0	incongruent_correct	1	2	incongruent	507	n/a
-57	172.5	1.0	incongruent_correct	1	2	incongruent	641	n/a
-58	175.0	1.0	congruent_correct	1	1	congruent	1623	n/a
-59	177.5	1.0	congruent_correct	1	1	congruent	606	n/a
-60	185.0	1.0	incongruent_correct	1	2	incongruent	723	n/a
-61	187.5	1.0	congruent_correct	1	1	congruent	451	n/a
-62	190.0	1.0	congruent_correct	1	1	congruent	385	n/a
-63	192.5	1.0	incongruent_incorrect	0	2	incongruent	689	n/a
-64	195.0	1.0	incongruent_correct	1	2	incongruent	783	n/a
-65	197.5	1.0	incongruent_correct	1	2	incongruent	854	n/a
-66	200.0	1.0	incongruent_correct	1	2	incongruent	836	n/a
-67	202.5	1.0	congruent_correct	1	1	congruent	940	n/a
-68	210.0	1.0	incongruent_correct	1	2	incongruent	792	n/a
-69	212.5	1.0	incongruent_correct	1	2	incongruent	503	n/a
-70	215.0	1.0	congruent_correct	1	1	congruent	423	n/a
-71	217.5	1.0	incongruent_correct	1	2	incongruent	725	n/a
-72	225.0	1.0	congruent_correct	1	1	congruent	1114	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	497	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	568	n/a
-75	232.5	1.0	congruent_incorrect	0	1	congruent	806	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	709	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	868	n/a
-78	240.0	1.0	congruent_correct	1	1	congruent	699	n/a
-79	242.5	1.0	incongruent_correct	1	2	incongruent	562	n/a
-80	245.0	1.0	incongruent_correct	1	2	incongruent	848	n/a
-81	247.5	1.0	congruent_correct	1	1	congruent	735	n/a
-82	250.0	1.0	incongruent_correct	1	2	incongruent	558	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	757	n/a
-84	260.0	1.0	incongruent_correct	1	2	incongruent	1489	n/a
-85	262.5	1.0	congruent_correct	1	1	congruent	737	n/a
-86	270.0	1.0	congruent_correct	1	1	congruent	638	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	1204	n/a
-88	275.0	1.0	incongruent_correct	1	2	incongruent	500	n/a
-89	277.5	1.0	congruent_correct	1	1	congruent	666	n/a
-90	285.0	1.0	congruent_correct	1	1	congruent	879	n/a
-91	287.5	1.0	incongruent_correct	1	2	incongruent	599	n/a
-92	290.0	1.0	congruent_correct	1	1	congruent	677	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	668	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	794	n/a
-95	297.5	1.0	incongruent_correct	1	2	incongruent	690	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	1	1	congruent	616	n/a
+2.5	1.0	congruent_correct	1	1	congruent	558	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	867	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	530	n/a
+15.0	1.0	incongruent_correct	1	2	incongruent	561	n/a
+17.5	1.0	incongruent_correct	1	2	incongruent	360	n/a
+25.0	1.0	congruent_correct	1	1	congruent	732	n/a
+27.5	1.0	congruent_correct	1	1	congruent	700	n/a
+30.0	1.0	incongruent_correct	1	2	incongruent	698	n/a
+32.5	1.0	congruent_correct	1	1	congruent	545	n/a
+35.0	1.0	incongruent_incorrect	0	2	incongruent	384	n/a
+37.5	1.0	congruent_correct	1	1	congruent	607	n/a
+40.0	1.0	congruent_correct	1	1	congruent	510	n/a
+42.5	1.0	incongruent_correct	1	2	incongruent	580	n/a
+45.0	1.0	incongruent_correct	1	2	incongruent	571	n/a
+47.5	1.0	incongruent_correct	1	2	incongruent	858	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	401	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	575	n/a
+60.0	1.0	congruent_correct	1	1	congruent	660	n/a
+62.5	1.0	congruent_correct	1	1	congruent	508	n/a
+65.0	1.0	congruent_correct	1	1	congruent	794	n/a
+67.5	1.0	congruent_correct	1	1	congruent	409	n/a
+75.0	1.0	congruent_correct	1	1	congruent	893	n/a
+77.5	1.0	congruent_correct	1	1	congruent	701	n/a
+80.0	1.0	congruent_correct	1	1	congruent	532	n/a
+82.5	1.0	incongruent_correct	1	2	incongruent	555	n/a
+85.0	1.0	incongruent_correct	1	2	incongruent	658	n/a
+87.5	1.0	congruent_correct	1	1	congruent	960	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	639	n/a
+92.5	1.0	congruent_incorrect	0	1	congruent	694	n/a
+95.0	1.0	congruent_correct	1	1	congruent	789	n/a
+97.5	1.0	incongruent_correct	1	2	incongruent	643	n/a
+100.0	1.0	congruent_correct	1	1	congruent	570	n/a
+102.5	1.0	incongruent_incorrect	0	2	incongruent	442	n/a
+105.0	1.0	incongruent_correct	1	2	incongruent	320	n/a
+107.5	1.0	incongruent_correct	1	2	incongruent	583	n/a
+110.0	1.0	congruent_correct	1	1	congruent	509	n/a
+112.5	1.0	congruent_correct	1	1	congruent	629	n/a
+120.0	1.0	congruent_correct	1	1	congruent	817	n/a
+122.5	1.0	congruent_correct	1	1	congruent	520	n/a
+125.0	1.0	congruent_correct	1	1	congruent	504	n/a
+127.5	1.0	congruent_correct	1	1	congruent	462	n/a
+130.0	1.0	congruent_correct	1	1	congruent	597	n/a
+132.5	1.0	incongruent_correct	1	2	incongruent	795	n/a
+135.0	1.0	congruent_correct	1	1	congruent	602	n/a
+137.5	1.0	incongruent_incorrect	0	2	incongruent	1017	n/a
+140.0	1.0	congruent_correct	1	1	congruent	832	n/a
+142.5	1.0	incongruent_correct	1	2	incongruent	1014	n/a
+150.0	1.0	incongruent_correct	1	2	incongruent	899	n/a
+152.5	1.0	congruent_correct	1	1	congruent	539	n/a
+155.0	1.0	incongruent_correct	1	2	incongruent	569	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	576	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	615	n/a
+162.5	1.0	incongruent_correct	1	2	incongruent	606	n/a
+165.0	1.0	incongruent_correct	1	2	incongruent	573	n/a
+167.5	1.0	incongruent_correct	1	2	incongruent	675	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	507	n/a
+172.5	1.0	incongruent_correct	1	2	incongruent	641	n/a
+175.0	1.0	congruent_correct	1	1	congruent	1623	n/a
+177.5	1.0	congruent_correct	1	1	congruent	606	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	723	n/a
+187.5	1.0	congruent_correct	1	1	congruent	451	n/a
+190.0	1.0	congruent_correct	1	1	congruent	385	n/a
+192.5	1.0	incongruent_incorrect	0	2	incongruent	689	n/a
+195.0	1.0	incongruent_correct	1	2	incongruent	783	n/a
+197.5	1.0	incongruent_correct	1	2	incongruent	854	n/a
+200.0	1.0	incongruent_correct	1	2	incongruent	836	n/a
+202.5	1.0	congruent_correct	1	1	congruent	940	n/a
+210.0	1.0	incongruent_correct	1	2	incongruent	792	n/a
+212.5	1.0	incongruent_correct	1	2	incongruent	503	n/a
+215.0	1.0	congruent_correct	1	1	congruent	423	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	725	n/a
+225.0	1.0	congruent_correct	1	1	congruent	1114	n/a
+227.5	1.0	congruent_correct	1	1	congruent	497	n/a
+230.0	1.0	congruent_correct	1	1	congruent	568	n/a
+232.5	1.0	congruent_incorrect	0	1	congruent	806	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	709	n/a
+237.5	1.0	congruent_correct	1	1	congruent	868	n/a
+240.0	1.0	congruent_correct	1	1	congruent	699	n/a
+242.5	1.0	incongruent_correct	1	2	incongruent	562	n/a
+245.0	1.0	incongruent_correct	1	2	incongruent	848	n/a
+247.5	1.0	congruent_correct	1	1	congruent	735	n/a
+250.0	1.0	incongruent_correct	1	2	incongruent	558	n/a
+252.5	1.0	congruent_correct	1	1	congruent	757	n/a
+260.0	1.0	incongruent_correct	1	2	incongruent	1489	n/a
+262.5	1.0	congruent_correct	1	1	congruent	737	n/a
+270.0	1.0	congruent_correct	1	1	congruent	638	n/a
+272.5	1.0	congruent_correct	1	1	congruent	1204	n/a
+275.0	1.0	incongruent_correct	1	2	incongruent	500	n/a
+277.5	1.0	congruent_correct	1	1	congruent	666	n/a
+285.0	1.0	congruent_correct	1	1	congruent	879	n/a
+287.5	1.0	incongruent_correct	1	2	incongruent	599	n/a
+290.0	1.0	congruent_correct	1	1	congruent	677	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	668	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	794	n/a
+297.5	1.0	incongruent_correct	1	2	incongruent	690	n/a

--- a/ds101/sub-20/func/sub-20_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-20/func/sub-20_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	1	2	incongruent	490	n/a
-1	2.5	1.0	incongruent_correct	1	2	incongruent	385	n/a
-2	5.0	1.0	congruent_correct	1	1	congruent	336	n/a
-3	7.5	1.0	congruent_correct	1	1	congruent	462	n/a
-4	10.0	1.0	incongruent_correct	1	2	incongruent	358	n/a
-5	12.5	1.0	incongruent_correct	1	2	incongruent	356	n/a
-6	20.0	1.0	incongruent_correct	1	2	incongruent	473	n/a
-7	22.5	1.0	incongruent_correct	1	2	incongruent	536	n/a
-8	25.0	1.0	congruent_correct	1	1	congruent	335	n/a
-9	27.5	1.0	congruent_correct	1	1	congruent	421	n/a
-10	30.0	1.0	congruent_correct	1	1	congruent	437	n/a
-11	32.5	1.0	congruent_correct	1	1	congruent	323	n/a
-12	45.0	1.0	congruent_correct	1	1	congruent	485	n/a
-13	47.5	1.0	congruent_correct	1	1	congruent	349	n/a
-14	50.0	1.0	incongruent_correct	1	2	incongruent	452	n/a
-15	52.5	1.0	incongruent_correct	1	2	incongruent	379	n/a
-16	55.0	1.0	congruent_correct	1	1	congruent	409	n/a
-17	57.5	1.0	incongruent_correct	1	2	incongruent	344	n/a
-18	65.0	1.0	congruent_correct	1	1	congruent	348	n/a
-19	67.5	1.0	incongruent_correct	1	2	incongruent	436	n/a
-20	70.0	1.0	incongruent_incorrect	0	2	incongruent	347	n/a
-21	72.5	1.0	incongruent_correct	1	2	incongruent	466	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	344	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	431	n/a
-24	80.0	1.0	congruent_correct	1	1	congruent	374	n/a
-25	82.5	1.0	congruent_correct	1	1	congruent	317	n/a
-26	85.0	1.0	congruent_correct	1	1	congruent	427	n/a
-27	87.5	1.0	incongruent_correct	1	2	incongruent	411	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	369	n/a
-29	92.5	1.0	congruent_correct	1	1	congruent	432	n/a
-30	95.0	1.0	incongruent_correct	1	2	incongruent	526	n/a
-31	97.5	1.0	incongruent_correct	1	2	incongruent	478	n/a
-32	100.0	1.0	incongruent_correct	1	2	incongruent	420	n/a
-33	102.5	1.0	incongruent_correct	1	2	incongruent	483	n/a
-34	105.0	1.0	congruent_correct	1	1	congruent	497	n/a
-35	107.5	1.0	congruent_correct	1	1	congruent	377	n/a
-36	110.0	1.0	incongruent_correct	1	2	incongruent	456	n/a
-37	112.5	1.0	incongruent_correct	1	2	incongruent	350	n/a
-38	120.0	1.0	incongruent_correct	1	2	incongruent	331	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	466	n/a
-40	125.0	1.0	congruent_correct	1	1	congruent	433	n/a
-41	127.5	1.0	congruent_correct	1	1	congruent	456	n/a
-42	135.0	1.0	incongruent_correct	1	2	incongruent	549	n/a
-43	137.5	1.0	congruent_correct	1	1	congruent	492	n/a
-44	140.0	1.0	congruent_correct	1	1	congruent	355	n/a
-45	142.5	1.0	incongruent_correct	1	2	incongruent	433	n/a
-46	145.0	1.0	congruent_correct	1	1	congruent	441	n/a
-47	147.5	1.0	incongruent_incorrect	0	2	incongruent	367	n/a
-48	150.0	1.0	congruent_correct	1	1	congruent	430	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	412	n/a
-50	155.0	1.0	congruent_correct	1	1	congruent	324	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	482	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	489	n/a
-53	162.5	1.0	congruent_correct	1	1	congruent	367	n/a
-54	170.0	1.0	incongruent_correct	1	2	incongruent	477	n/a
-55	172.5	1.0	congruent_correct	1	1	congruent	427	n/a
-56	175.0	1.0	congruent_correct	1	1	congruent	379	n/a
-57	177.5	1.0	incongruent_correct	1	2	incongruent	442	n/a
-58	185.0	1.0	incongruent_correct	1	2	incongruent	454	n/a
-59	187.5	1.0	incongruent_correct	1	2	incongruent	446	n/a
-60	190.0	1.0	incongruent_correct	1	2	incongruent	580	n/a
-61	192.5	1.0	incongruent_correct	1	2	incongruent	347	n/a
-62	195.0	1.0	congruent_incorrect	0	1	congruent	410	n/a
-63	197.5	1.0	congruent_correct	1	1	congruent	321	n/a
-64	200.0	1.0	congruent_correct	1	1	congruent	335	n/a
-65	202.5	1.0	incongruent_correct	1	2	incongruent	414	n/a
-66	205.0	1.0	incongruent_correct	1	2	incongruent	397	n/a
-67	207.5	1.0	incongruent_correct	1	2	incongruent	420	n/a
-68	215.0	1.0	incongruent_correct	1	2	incongruent	496	n/a
-69	217.5	1.0	incongruent_correct	1	2	incongruent	440	n/a
-70	220.0	1.0	congruent_correct	1	1	congruent	358	n/a
-71	222.5	1.0	incongruent_correct	1	2	incongruent	413	n/a
-72	225.0	1.0	incongruent_correct	1	2	incongruent	380	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	427	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	281	n/a
-75	232.5	1.0	congruent_correct	1	1	congruent	369	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	383	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	366	n/a
-78	240.0	1.0	incongruent_incorrect	0	2	incongruent	357	n/a
-79	242.5	1.0	congruent_correct	1	1	congruent	444	n/a
-80	245.0	1.0	congruent_correct	1	1	congruent	483	n/a
-81	247.5	1.0	incongruent_correct	1	2	incongruent	473	n/a
-82	250.0	1.0	congruent_correct	1	1	congruent	385	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	551	n/a
-84	255.0	1.0	incongruent_correct	1	2	incongruent	422	n/a
-85	257.5	1.0	congruent_correct	1	1	congruent	412	n/a
-86	270.0	1.0	incongruent_correct	1	2	incongruent	703	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	374	n/a
-88	275.0	1.0	congruent_correct	1	1	congruent	357	n/a
-89	277.5	1.0	incongruent_correct	1	2	incongruent	355	n/a
-90	280.0	1.0	incongruent_correct	1	2	incongruent	459	n/a
-91	282.5	1.0	congruent_correct	1	1	congruent	409	n/a
-92	290.0	1.0	congruent_incorrect	0	1	congruent	590	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	421	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	340	n/a
-95	297.5	1.0	congruent_correct	1	1	congruent	354	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	1	2	incongruent	490	n/a
+2.5	1.0	incongruent_correct	1	2	incongruent	385	n/a
+5.0	1.0	congruent_correct	1	1	congruent	336	n/a
+7.5	1.0	congruent_correct	1	1	congruent	462	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	358	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	356	n/a
+20.0	1.0	incongruent_correct	1	2	incongruent	473	n/a
+22.5	1.0	incongruent_correct	1	2	incongruent	536	n/a
+25.0	1.0	congruent_correct	1	1	congruent	335	n/a
+27.5	1.0	congruent_correct	1	1	congruent	421	n/a
+30.0	1.0	congruent_correct	1	1	congruent	437	n/a
+32.5	1.0	congruent_correct	1	1	congruent	323	n/a
+45.0	1.0	congruent_correct	1	1	congruent	485	n/a
+47.5	1.0	congruent_correct	1	1	congruent	349	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	452	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	379	n/a
+55.0	1.0	congruent_correct	1	1	congruent	409	n/a
+57.5	1.0	incongruent_correct	1	2	incongruent	344	n/a
+65.0	1.0	congruent_correct	1	1	congruent	348	n/a
+67.5	1.0	incongruent_correct	1	2	incongruent	436	n/a
+70.0	1.0	incongruent_incorrect	0	2	incongruent	347	n/a
+72.5	1.0	incongruent_correct	1	2	incongruent	466	n/a
+75.0	1.0	congruent_correct	1	1	congruent	344	n/a
+77.5	1.0	congruent_correct	1	1	congruent	431	n/a
+80.0	1.0	congruent_correct	1	1	congruent	374	n/a
+82.5	1.0	congruent_correct	1	1	congruent	317	n/a
+85.0	1.0	congruent_correct	1	1	congruent	427	n/a
+87.5	1.0	incongruent_correct	1	2	incongruent	411	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	369	n/a
+92.5	1.0	congruent_correct	1	1	congruent	432	n/a
+95.0	1.0	incongruent_correct	1	2	incongruent	526	n/a
+97.5	1.0	incongruent_correct	1	2	incongruent	478	n/a
+100.0	1.0	incongruent_correct	1	2	incongruent	420	n/a
+102.5	1.0	incongruent_correct	1	2	incongruent	483	n/a
+105.0	1.0	congruent_correct	1	1	congruent	497	n/a
+107.5	1.0	congruent_correct	1	1	congruent	377	n/a
+110.0	1.0	incongruent_correct	1	2	incongruent	456	n/a
+112.5	1.0	incongruent_correct	1	2	incongruent	350	n/a
+120.0	1.0	incongruent_correct	1	2	incongruent	331	n/a
+122.5	1.0	congruent_correct	1	1	congruent	466	n/a
+125.0	1.0	congruent_correct	1	1	congruent	433	n/a
+127.5	1.0	congruent_correct	1	1	congruent	456	n/a
+135.0	1.0	incongruent_correct	1	2	incongruent	549	n/a
+137.5	1.0	congruent_correct	1	1	congruent	492	n/a
+140.0	1.0	congruent_correct	1	1	congruent	355	n/a
+142.5	1.0	incongruent_correct	1	2	incongruent	433	n/a
+145.0	1.0	congruent_correct	1	1	congruent	441	n/a
+147.5	1.0	incongruent_incorrect	0	2	incongruent	367	n/a
+150.0	1.0	congruent_correct	1	1	congruent	430	n/a
+152.5	1.0	congruent_correct	1	1	congruent	412	n/a
+155.0	1.0	congruent_correct	1	1	congruent	324	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	482	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	489	n/a
+162.5	1.0	congruent_correct	1	1	congruent	367	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	477	n/a
+172.5	1.0	congruent_correct	1	1	congruent	427	n/a
+175.0	1.0	congruent_correct	1	1	congruent	379	n/a
+177.5	1.0	incongruent_correct	1	2	incongruent	442	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	454	n/a
+187.5	1.0	incongruent_correct	1	2	incongruent	446	n/a
+190.0	1.0	incongruent_correct	1	2	incongruent	580	n/a
+192.5	1.0	incongruent_correct	1	2	incongruent	347	n/a
+195.0	1.0	congruent_incorrect	0	1	congruent	410	n/a
+197.5	1.0	congruent_correct	1	1	congruent	321	n/a
+200.0	1.0	congruent_correct	1	1	congruent	335	n/a
+202.5	1.0	incongruent_correct	1	2	incongruent	414	n/a
+205.0	1.0	incongruent_correct	1	2	incongruent	397	n/a
+207.5	1.0	incongruent_correct	1	2	incongruent	420	n/a
+215.0	1.0	incongruent_correct	1	2	incongruent	496	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	440	n/a
+220.0	1.0	congruent_correct	1	1	congruent	358	n/a
+222.5	1.0	incongruent_correct	1	2	incongruent	413	n/a
+225.0	1.0	incongruent_correct	1	2	incongruent	380	n/a
+227.5	1.0	congruent_correct	1	1	congruent	427	n/a
+230.0	1.0	congruent_correct	1	1	congruent	281	n/a
+232.5	1.0	congruent_correct	1	1	congruent	369	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	383	n/a
+237.5	1.0	congruent_correct	1	1	congruent	366	n/a
+240.0	1.0	incongruent_incorrect	0	2	incongruent	357	n/a
+242.5	1.0	congruent_correct	1	1	congruent	444	n/a
+245.0	1.0	congruent_correct	1	1	congruent	483	n/a
+247.5	1.0	incongruent_correct	1	2	incongruent	473	n/a
+250.0	1.0	congruent_correct	1	1	congruent	385	n/a
+252.5	1.0	congruent_correct	1	1	congruent	551	n/a
+255.0	1.0	incongruent_correct	1	2	incongruent	422	n/a
+257.5	1.0	congruent_correct	1	1	congruent	412	n/a
+270.0	1.0	incongruent_correct	1	2	incongruent	703	n/a
+272.5	1.0	congruent_correct	1	1	congruent	374	n/a
+275.0	1.0	congruent_correct	1	1	congruent	357	n/a
+277.5	1.0	incongruent_correct	1	2	incongruent	355	n/a
+280.0	1.0	incongruent_correct	1	2	incongruent	459	n/a
+282.5	1.0	congruent_correct	1	1	congruent	409	n/a
+290.0	1.0	congruent_incorrect	0	1	congruent	590	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	421	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	340	n/a
+297.5	1.0	congruent_correct	1	1	congruent	354	n/a

--- a/ds101/sub-20/func/sub-20_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-20/func/sub-20_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	1	1	congruent	367	n/a
-1	2.5	1.0	congruent_correct	1	1	congruent	334	n/a
-2	10.0	1.0	incongruent_correct	1	2	incongruent	474	n/a
-3	12.5	1.0	incongruent_correct	1	2	incongruent	370	n/a
-4	15.0	1.0	incongruent_correct	1	2	incongruent	408	n/a
-5	17.5	1.0	incongruent_correct	1	2	incongruent	327	n/a
-6	25.0	1.0	congruent_correct	1	1	congruent	420	n/a
-7	27.5	1.0	congruent_correct	1	1	congruent	347	n/a
-8	30.0	1.0	incongruent_correct	1	2	incongruent	346	n/a
-9	32.5	1.0	congruent_correct	1	1	congruent	401	n/a
-10	35.0	1.0	incongruent_correct	1	2	incongruent	407	n/a
-11	37.5	1.0	congruent_correct	1	1	congruent	494	n/a
-12	40.0	1.0	congruent_correct	1	1	congruent	285	n/a
-13	42.5	1.0	incongruent_correct	1	2	incongruent	412	n/a
-14	45.0	1.0	incongruent_correct	1	2	incongruent	426	n/a
-15	47.5	1.0	incongruent_correct	1	2	incongruent	474	n/a
-16	50.0	1.0	incongruent_correct	1	2	incongruent	440	n/a
-17	52.5	1.0	incongruent_correct	1	2	incongruent	327	n/a
-18	60.0	1.0	congruent_correct	1	1	congruent	508	n/a
-19	62.5	1.0	congruent_correct	1	1	congruent	371	n/a
-20	65.0	1.0	congruent_correct	1	1	congruent	330	n/a
-21	67.5	1.0	congruent_correct	1	1	congruent	337	n/a
-22	75.0	1.0	congruent_correct	1	1	congruent	478	n/a
-23	77.5	1.0	congruent_correct	1	1	congruent	332	n/a
-24	80.0	1.0	congruent_correct	1	1	congruent	332	n/a
-25	82.5	1.0	incongruent_incorrect	0	2	incongruent	346	n/a
-26	85.0	1.0	incongruent_correct	1	2	incongruent	425	n/a
-27	87.5	1.0	congruent_correct	1	1	congruent	440	n/a
-28	90.0	1.0	incongruent_correct	1	2	incongruent	431	n/a
-29	92.5	1.0	congruent_correct	1	1	congruent	453	n/a
-30	95.0	1.0	congruent_correct	1	1	congruent	340	n/a
-31	97.5	1.0	incongruent_correct	1	2	incongruent	515	n/a
-32	100.0	1.0	congruent_correct	1	1	congruent	506	n/a
-33	102.5	1.0	incongruent_correct	1	2	incongruent	360	n/a
-34	105.0	1.0	incongruent_correct	1	2	incongruent	320	n/a
-35	107.5	1.0	incongruent_correct	1	2	incongruent	302	n/a
-36	110.0	1.0	congruent_correct	1	1	congruent	333	n/a
-37	112.5	1.0	congruent_correct	1	1	congruent	316	n/a
-38	120.0	1.0	congruent_correct	1	1	congruent	432	n/a
-39	122.5	1.0	congruent_correct	1	1	congruent	344	n/a
-40	125.0	1.0	congruent_correct	1	1	congruent	327	n/a
-41	127.5	1.0	congruent_correct	1	1	congruent	430	n/a
-42	130.0	1.0	congruent_correct	1	1	congruent	412	n/a
-43	132.5	1.0	incongruent_correct	1	2	incongruent	467	n/a
-44	135.0	1.0	congruent_correct	1	1	congruent	354	n/a
-45	137.5	1.0	incongruent_incorrect	0	2	incongruent	337	n/a
-46	140.0	1.0	congruent_correct	1	1	congruent	375	n/a
-47	142.5	1.0	incongruent_correct	1	2	incongruent	454	n/a
-48	150.0	1.0	incongruent_correct	1	2	incongruent	491	n/a
-49	152.5	1.0	congruent_correct	1	1	congruent	418	n/a
-50	155.0	1.0	incongruent_correct	1	2	incongruent	457	n/a
-51	157.5	1.0	incongruent_correct	1	2	incongruent	352	n/a
-52	160.0	1.0	incongruent_correct	1	2	incongruent	414	n/a
-53	162.5	1.0	incongruent_correct	1	2	incongruent	398	n/a
-54	165.0	1.0	incongruent_correct	1	2	incongruent	716	n/a
-55	167.5	1.0	incongruent_correct	1	2	incongruent	395	n/a
-56	170.0	1.0	incongruent_correct	1	2	incongruent	329	n/a
-57	172.5	1.0	incongruent_correct	1	2	incongruent	321	n/a
-58	175.0	1.0	congruent_correct	1	1	congruent	319	n/a
-59	177.5	1.0	congruent_incorrect	0	1	congruent	414	n/a
-60	185.0	1.0	incongruent_correct	1	2	incongruent	475	n/a
-61	187.5	1.0	congruent_correct	1	1	congruent	322	n/a
-62	190.0	1.0	congruent_correct	1	1	congruent	329	n/a
-63	192.5	1.0	incongruent_correct	1	2	incongruent	392	n/a
-64	195.0	1.0	incongruent_correct	1	2	incongruent	431	n/a
-65	197.5	1.0	incongruent_correct	1	2	incongruent	421	n/a
-66	200.0	1.0	incongruent_correct	1	2	incongruent	380	n/a
-67	202.5	1.0	congruent_correct	1	1	congruent	531	n/a
-68	210.0	1.0	incongruent_incorrect	0	2	incongruent	384	n/a
-69	212.5	1.0	incongruent_correct	1	2	incongruent	455	n/a
-70	215.0	1.0	congruent_correct	1	1	congruent	438	n/a
-71	217.5	1.0	incongruent_correct	1	2	incongruent	380	n/a
-72	225.0	1.0	congruent_correct	1	1	congruent	417	n/a
-73	227.5	1.0	congruent_correct	1	1	congruent	352	n/a
-74	230.0	1.0	congruent_correct	1	1	congruent	487	n/a
-75	232.5	1.0	congruent_correct	1	1	congruent	303	n/a
-76	235.0	1.0	incongruent_correct	1	2	incongruent	469	n/a
-77	237.5	1.0	congruent_correct	1	1	congruent	387	n/a
-78	240.0	1.0	congruent_correct	1	1	congruent	322	n/a
-79	242.5	1.0	incongruent_correct	1	2	incongruent	425	n/a
-80	245.0	1.0	incongruent_correct	1	2	incongruent	392	n/a
-81	247.5	1.0	congruent_correct	1	1	congruent	366	n/a
-82	250.0	1.0	incongruent_correct	1	2	incongruent	406	n/a
-83	252.5	1.0	congruent_correct	1	1	congruent	333	n/a
-84	260.0	1.0	incongruent_correct	1	2	incongruent	473	n/a
-85	262.5	1.0	congruent_correct	1	1	congruent	345	n/a
-86	270.0	1.0	congruent_correct	1	1	congruent	341	n/a
-87	272.5	1.0	congruent_correct	1	1	congruent	349	n/a
-88	275.0	1.0	incongruent_incorrect	0	2	incongruent	371	n/a
-89	277.5	1.0	congruent_correct	1	1	congruent	386	n/a
-90	285.0	1.0	congruent_correct	1	1	congruent	438	n/a
-91	287.5	1.0	incongruent_correct	1	2	incongruent	382	n/a
-92	290.0	1.0	congruent_correct	1	1	congruent	308	n/a
-93	292.5	1.0	incongruent_correct	1	2	incongruent	500	n/a
-94	295.0	1.0	incongruent_correct	1	2	incongruent	442	n/a
-95	297.5	1.0	incongruent_correct	1	2	incongruent	481	n/a
+onset	duration	trial_type	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	1	1	congruent	367	n/a
+2.5	1.0	congruent_correct	1	1	congruent	334	n/a
+10.0	1.0	incongruent_correct	1	2	incongruent	474	n/a
+12.5	1.0	incongruent_correct	1	2	incongruent	370	n/a
+15.0	1.0	incongruent_correct	1	2	incongruent	408	n/a
+17.5	1.0	incongruent_correct	1	2	incongruent	327	n/a
+25.0	1.0	congruent_correct	1	1	congruent	420	n/a
+27.5	1.0	congruent_correct	1	1	congruent	347	n/a
+30.0	1.0	incongruent_correct	1	2	incongruent	346	n/a
+32.5	1.0	congruent_correct	1	1	congruent	401	n/a
+35.0	1.0	incongruent_correct	1	2	incongruent	407	n/a
+37.5	1.0	congruent_correct	1	1	congruent	494	n/a
+40.0	1.0	congruent_correct	1	1	congruent	285	n/a
+42.5	1.0	incongruent_correct	1	2	incongruent	412	n/a
+45.0	1.0	incongruent_correct	1	2	incongruent	426	n/a
+47.5	1.0	incongruent_correct	1	2	incongruent	474	n/a
+50.0	1.0	incongruent_correct	1	2	incongruent	440	n/a
+52.5	1.0	incongruent_correct	1	2	incongruent	327	n/a
+60.0	1.0	congruent_correct	1	1	congruent	508	n/a
+62.5	1.0	congruent_correct	1	1	congruent	371	n/a
+65.0	1.0	congruent_correct	1	1	congruent	330	n/a
+67.5	1.0	congruent_correct	1	1	congruent	337	n/a
+75.0	1.0	congruent_correct	1	1	congruent	478	n/a
+77.5	1.0	congruent_correct	1	1	congruent	332	n/a
+80.0	1.0	congruent_correct	1	1	congruent	332	n/a
+82.5	1.0	incongruent_incorrect	0	2	incongruent	346	n/a
+85.0	1.0	incongruent_correct	1	2	incongruent	425	n/a
+87.5	1.0	congruent_correct	1	1	congruent	440	n/a
+90.0	1.0	incongruent_correct	1	2	incongruent	431	n/a
+92.5	1.0	congruent_correct	1	1	congruent	453	n/a
+95.0	1.0	congruent_correct	1	1	congruent	340	n/a
+97.5	1.0	incongruent_correct	1	2	incongruent	515	n/a
+100.0	1.0	congruent_correct	1	1	congruent	506	n/a
+102.5	1.0	incongruent_correct	1	2	incongruent	360	n/a
+105.0	1.0	incongruent_correct	1	2	incongruent	320	n/a
+107.5	1.0	incongruent_correct	1	2	incongruent	302	n/a
+110.0	1.0	congruent_correct	1	1	congruent	333	n/a
+112.5	1.0	congruent_correct	1	1	congruent	316	n/a
+120.0	1.0	congruent_correct	1	1	congruent	432	n/a
+122.5	1.0	congruent_correct	1	1	congruent	344	n/a
+125.0	1.0	congruent_correct	1	1	congruent	327	n/a
+127.5	1.0	congruent_correct	1	1	congruent	430	n/a
+130.0	1.0	congruent_correct	1	1	congruent	412	n/a
+132.5	1.0	incongruent_correct	1	2	incongruent	467	n/a
+135.0	1.0	congruent_correct	1	1	congruent	354	n/a
+137.5	1.0	incongruent_incorrect	0	2	incongruent	337	n/a
+140.0	1.0	congruent_correct	1	1	congruent	375	n/a
+142.5	1.0	incongruent_correct	1	2	incongruent	454	n/a
+150.0	1.0	incongruent_correct	1	2	incongruent	491	n/a
+152.5	1.0	congruent_correct	1	1	congruent	418	n/a
+155.0	1.0	incongruent_correct	1	2	incongruent	457	n/a
+157.5	1.0	incongruent_correct	1	2	incongruent	352	n/a
+160.0	1.0	incongruent_correct	1	2	incongruent	414	n/a
+162.5	1.0	incongruent_correct	1	2	incongruent	398	n/a
+165.0	1.0	incongruent_correct	1	2	incongruent	716	n/a
+167.5	1.0	incongruent_correct	1	2	incongruent	395	n/a
+170.0	1.0	incongruent_correct	1	2	incongruent	329	n/a
+172.5	1.0	incongruent_correct	1	2	incongruent	321	n/a
+175.0	1.0	congruent_correct	1	1	congruent	319	n/a
+177.5	1.0	congruent_incorrect	0	1	congruent	414	n/a
+185.0	1.0	incongruent_correct	1	2	incongruent	475	n/a
+187.5	1.0	congruent_correct	1	1	congruent	322	n/a
+190.0	1.0	congruent_correct	1	1	congruent	329	n/a
+192.5	1.0	incongruent_correct	1	2	incongruent	392	n/a
+195.0	1.0	incongruent_correct	1	2	incongruent	431	n/a
+197.5	1.0	incongruent_correct	1	2	incongruent	421	n/a
+200.0	1.0	incongruent_correct	1	2	incongruent	380	n/a
+202.5	1.0	congruent_correct	1	1	congruent	531	n/a
+210.0	1.0	incongruent_incorrect	0	2	incongruent	384	n/a
+212.5	1.0	incongruent_correct	1	2	incongruent	455	n/a
+215.0	1.0	congruent_correct	1	1	congruent	438	n/a
+217.5	1.0	incongruent_correct	1	2	incongruent	380	n/a
+225.0	1.0	congruent_correct	1	1	congruent	417	n/a
+227.5	1.0	congruent_correct	1	1	congruent	352	n/a
+230.0	1.0	congruent_correct	1	1	congruent	487	n/a
+232.5	1.0	congruent_correct	1	1	congruent	303	n/a
+235.0	1.0	incongruent_correct	1	2	incongruent	469	n/a
+237.5	1.0	congruent_correct	1	1	congruent	387	n/a
+240.0	1.0	congruent_correct	1	1	congruent	322	n/a
+242.5	1.0	incongruent_correct	1	2	incongruent	425	n/a
+245.0	1.0	incongruent_correct	1	2	incongruent	392	n/a
+247.5	1.0	congruent_correct	1	1	congruent	366	n/a
+250.0	1.0	incongruent_correct	1	2	incongruent	406	n/a
+252.5	1.0	congruent_correct	1	1	congruent	333	n/a
+260.0	1.0	incongruent_correct	1	2	incongruent	473	n/a
+262.5	1.0	congruent_correct	1	1	congruent	345	n/a
+270.0	1.0	congruent_correct	1	1	congruent	341	n/a
+272.5	1.0	congruent_correct	1	1	congruent	349	n/a
+275.0	1.0	incongruent_incorrect	0	2	incongruent	371	n/a
+277.5	1.0	congruent_correct	1	1	congruent	386	n/a
+285.0	1.0	congruent_correct	1	1	congruent	438	n/a
+287.5	1.0	incongruent_correct	1	2	incongruent	382	n/a
+290.0	1.0	congruent_correct	1	1	congruent	308	n/a
+292.5	1.0	incongruent_correct	1	2	incongruent	500	n/a
+295.0	1.0	incongruent_correct	1	2	incongruent	442	n/a
+297.5	1.0	incongruent_correct	1	2	incongruent	481	n/a

--- a/ds101/sub-21/func/sub-21_task-Simontask_run-01_events.tsv
+++ b/ds101/sub-21/func/sub-21_task-Simontask_run-01_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	incongruent_correct	n/a	1	2	incongruent	699	n/a
-1	2.5	1.0	incongruent_correct	n/a	1	2	incongruent	522	n/a
-2	5.0	1.0	congruent_correct	n/a	1	1	congruent	506	n/a
-3	7.5	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
-4	10.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	447	n/a
-5	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	565	n/a
-6	20.0	1.0	incongruent_correct	n/a	1	2	incongruent	603	n/a
-7	22.5	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
-8	25.0	1.0	congruent_correct	n/a	1	1	congruent	760	n/a
-9	27.5	1.0	congruent_correct	n/a	1	1	congruent	352	n/a
-10	30.0	1.0	congruent_correct	n/a	1	1	congruent	582	n/a
-11	32.5	1.0	congruent_correct	n/a	1	1	congruent	565	n/a
-12	45.0	1.0	congruent_correct	n/a	1	1	congruent	487	n/a
-13	47.5	1.0	congruent_correct	n/a	1	1	congruent	422	n/a
-14	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	573	n/a
-15	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-16	55.0	1.0	congruent_correct	n/a	1	1	congruent	499	n/a
-17	57.5	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
-18	65.0	1.0	congruent_correct	n/a	1	1	congruent	646	n/a
-19	67.5	1.0	incongruent_correct	n/a	1	2	incongruent	589	n/a
-20	70.0	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
-21	72.5	1.0	incongruent_correct	n/a	1	2	incongruent	564	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	626	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	545	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	519	n/a
-25	82.5	1.0	congruent_correct	n/a	1	1	congruent	335	n/a
-26	85.0	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
-27	87.5	1.0	incongruent_correct	n/a	1	2	incongruent	508	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	410	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	410	n/a
-30	95.0	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
-32	100.0	1.0	incongruent_correct	n/a	1	2	incongruent	494	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	493	n/a
-34	105.0	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
-35	107.5	1.0	congruent_correct	n/a	1	1	congruent	450	n/a
-36	110.0	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
-37	112.5	1.0	incongruent_correct	n/a	1	2	incongruent	584	n/a
-38	120.0	1.0	incongruent_correct	n/a	1	2	incongruent	629	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	500	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	666	n/a
-42	135.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
-43	137.5	1.0	congruent_correct	n/a	1	1	congruent	326	n/a
-44	140.0	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
-45	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
-46	145.0	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
-47	147.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
-48	150.0	1.0	congruent_correct	n/a	1	1	congruent	480	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	446	n/a
-50	155.0	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
-53	162.5	1.0	congruent_correct	n/a	1	1	congruent	401	n/a
-54	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	598	n/a
-55	172.5	1.0	congruent_correct	n/a	1	1	congruent	454	n/a
-56	175.0	1.0	congruent_correct	n/a	1	1	congruent	548	n/a
-57	177.5	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
-58	185.0	1.0	incongruent_correct	n/a	1	2	incongruent	639	n/a
-59	187.5	1.0	incongruent_correct	n/a	1	2	incongruent	383	n/a
-60	190.0	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
-61	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	404	n/a
-62	195.0	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
-63	197.5	1.0	congruent_correct	n/a	1	1	congruent	370	n/a
-64	200.0	1.0	congruent_correct	n/a	1	1	congruent	345	n/a
-65	202.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
-66	205.0	1.0	incongruent_correct	n/a	1	2	incongruent	463	n/a
-67	207.5	1.0	incongruent_correct	n/a	1	2	incongruent	581	n/a
-68	215.0	1.0	incongruent_correct	n/a	1	2	incongruent	530	n/a
-69	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	410	n/a
-70	220.0	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
-71	222.5	1.0	incongruent_correct	n/a	1	2	incongruent	487	n/a
-72	225.0	1.0	incongruent_correct	n/a	1	2	incongruent	349	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	709	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	579	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
-76	235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	433	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
-78	240.0	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
-79	242.5	1.0	congruent_correct	n/a	1	1	congruent	333	n/a
-80	245.0	1.0	congruent_correct	n/a	1	1	congruent	412	n/a
-81	247.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	331	n/a
-82	250.0	1.0	congruent_correct	n/a	1	1	congruent	618	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
-84	255.0	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
-85	257.5	1.0	congruent_correct	n/a	1	1	congruent	695	n/a
-86	270.0	1.0	incongruent_correct	n/a	1	2	incongruent	592	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	368	n/a
-88	275.0	1.0	congruent_correct	n/a	1	1	congruent	470	n/a
-89	277.5	1.0	incongruent_correct	n/a	1	2	incongruent	477	n/a
-90	280.0	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
-91	282.5	1.0	congruent_correct	n/a	1	1	congruent	411	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	584	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	454	n/a
-95	297.5	1.0	congruent_correct	n/a	1	1	congruent	572	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	incongruent_correct	n/a	1	2	incongruent	699	n/a
+2.5	1.0	incongruent_correct	n/a	1	2	incongruent	522	n/a
+5.0	1.0	congruent_correct	n/a	1	1	congruent	506	n/a
+7.5	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
+10.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	447	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	565	n/a
+20.0	1.0	incongruent_correct	n/a	1	2	incongruent	603	n/a
+22.5	1.0	incongruent_correct	n/a	1	2	incongruent	497	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	760	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	352	n/a
+30.0	1.0	congruent_correct	n/a	1	1	congruent	582	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	565	n/a
+45.0	1.0	congruent_correct	n/a	1	1	congruent	487	n/a
+47.5	1.0	congruent_correct	n/a	1	1	congruent	422	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	573	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+55.0	1.0	congruent_correct	n/a	1	1	congruent	499	n/a
+57.5	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	646	n/a
+67.5	1.0	incongruent_correct	n/a	1	2	incongruent	589	n/a
+70.0	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
+72.5	1.0	incongruent_correct	n/a	1	2	incongruent	564	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	626	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	545	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	519	n/a
+82.5	1.0	congruent_correct	n/a	1	1	congruent	335	n/a
+85.0	1.0	congruent_correct	n/a	1	1	congruent	541	n/a
+87.5	1.0	incongruent_correct	n/a	1	2	incongruent	508	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	410	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	410	n/a
+95.0	1.0	incongruent_correct	n/a	1	2	incongruent	480	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
+100.0	1.0	incongruent_correct	n/a	1	2	incongruent	494	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	493	n/a
+105.0	1.0	congruent_correct	n/a	1	1	congruent	404	n/a
+107.5	1.0	congruent_correct	n/a	1	1	congruent	450	n/a
+110.0	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
+112.5	1.0	incongruent_correct	n/a	1	2	incongruent	584	n/a
+120.0	1.0	incongruent_correct	n/a	1	2	incongruent	629	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	500	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	355	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	666	n/a
+135.0	1.0	incongruent_correct	n/a	1	2	incongruent	502	n/a
+137.5	1.0	congruent_correct	n/a	1	1	congruent	326	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	405	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	459	n/a
+145.0	1.0	congruent_correct	n/a	1	1	congruent	354	n/a
+147.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
+150.0	1.0	congruent_correct	n/a	1	1	congruent	480	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	446	n/a
+155.0	1.0	congruent_correct	n/a	1	1	congruent	429	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
+162.5	1.0	congruent_correct	n/a	1	1	congruent	401	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	598	n/a
+172.5	1.0	congruent_correct	n/a	1	1	congruent	454	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	548	n/a
+177.5	1.0	incongruent_correct	n/a	1	2	incongruent	443	n/a
+185.0	1.0	incongruent_correct	n/a	1	2	incongruent	639	n/a
+187.5	1.0	incongruent_correct	n/a	1	2	incongruent	383	n/a
+190.0	1.0	incongruent_correct	n/a	1	2	incongruent	422	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	404	n/a
+195.0	1.0	congruent_correct	n/a	1	1	congruent	436	n/a
+197.5	1.0	congruent_correct	n/a	1	1	congruent	370	n/a
+200.0	1.0	congruent_correct	n/a	1	1	congruent	345	n/a
+202.5	1.0	incongruent_correct	n/a	1	2	incongruent	447	n/a
+205.0	1.0	incongruent_correct	n/a	1	2	incongruent	463	n/a
+207.5	1.0	incongruent_correct	n/a	1	2	incongruent	581	n/a
+215.0	1.0	incongruent_correct	n/a	1	2	incongruent	530	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	410	n/a
+220.0	1.0	congruent_correct	n/a	1	1	congruent	384	n/a
+222.5	1.0	incongruent_correct	n/a	1	2	incongruent	487	n/a
+225.0	1.0	incongruent_correct	n/a	1	2	incongruent	349	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	709	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	579	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	434	n/a
+235.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	433	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	536	n/a
+240.0	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
+242.5	1.0	congruent_correct	n/a	1	1	congruent	333	n/a
+245.0	1.0	congruent_correct	n/a	1	1	congruent	412	n/a
+247.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	331	n/a
+250.0	1.0	congruent_correct	n/a	1	1	congruent	618	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	416	n/a
+255.0	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
+257.5	1.0	congruent_correct	n/a	1	1	congruent	695	n/a
+270.0	1.0	incongruent_correct	n/a	1	2	incongruent	592	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	368	n/a
+275.0	1.0	congruent_correct	n/a	1	1	congruent	470	n/a
+277.5	1.0	incongruent_correct	n/a	1	2	incongruent	477	n/a
+280.0	1.0	incongruent_correct	n/a	1	2	incongruent	525	n/a
+282.5	1.0	congruent_correct	n/a	1	1	congruent	411	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	584	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	567	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	454	n/a
+297.5	1.0	congruent_correct	n/a	1	1	congruent	572	n/a

--- a/ds101/sub-21/func/sub-21_task-Simontask_run-02_events.tsv
+++ b/ds101/sub-21/func/sub-21_task-Simontask_run-02_events.tsv
@@ -1,97 +1,97 @@
-	onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
-0	0.0	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
-1	2.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
-2	10.0	1.0	incongruent_correct	n/a	1	2	incongruent	529	n/a
-3	12.5	1.0	incongruent_correct	n/a	1	2	incongruent	615	n/a
-4	15.0	1.0	incongruent_correct	n/a	1	2	incongruent	487	n/a
-5	17.5	1.0	incongruent_correct	n/a	1	2	incongruent	477	n/a
-6	25.0	1.0	congruent_correct	n/a	1	1	congruent	730	n/a
-7	27.5	1.0	congruent_correct	n/a	1	1	congruent	338	n/a
-8	30.0	1.0	incongruent_correct	n/a	1	2	incongruent	504	n/a
-9	32.5	1.0	congruent_correct	n/a	1	1	congruent	615	n/a
-10	35.0	1.0	incongruent_correct	n/a	1	2	incongruent	469	n/a
-11	37.5	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
-12	40.0	1.0	congruent_correct	n/a	1	1	congruent	515	n/a
-13	42.5	1.0	incongruent_correct	n/a	1	2	incongruent	530	n/a
-14	45.0	1.0	incongruent_correct	n/a	1	2	incongruent	432	n/a
-15	47.5	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-16	50.0	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
-17	52.5	1.0	incongruent_correct	n/a	1	2	incongruent	509	n/a
-18	60.0	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
-19	62.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-20	65.0	1.0	congruent_correct	n/a	1	1	congruent	352	n/a
-21	67.5	1.0	congruent_correct	n/a	1	1	congruent	382	n/a
-22	75.0	1.0	congruent_correct	n/a	1	1	congruent	563	n/a
-23	77.5	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
-24	80.0	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
-25	82.5	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
-26	85.0	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
-27	87.5	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
-28	90.0	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
-29	92.5	1.0	congruent_correct	n/a	1	1	congruent	332	n/a
-30	95.0	1.0	congruent_correct	n/a	1	1	congruent	339	n/a
-31	97.5	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
-32	100.0	1.0	congruent_correct	n/a	1	1	congruent	376	n/a
-33	102.5	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
-34	105.0	1.0	incongruent_correct	n/a	1	2	incongruent	438	n/a
-35	107.5	1.0	incongruent_correct	n/a	1	2	incongruent	436	n/a
-36	110.0	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
-37	112.5	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
-38	120.0	1.0	congruent_correct	n/a	1	1	congruent	551	n/a
-39	122.5	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
-40	125.0	1.0	congruent_correct	n/a	1	1	congruent	325	n/a
-41	127.5	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
-42	130.0	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
-43	132.5	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
-44	135.0	1.0	congruent_correct	n/a	1	1	congruent	520	n/a
-45	137.5	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
-46	140.0	1.0	congruent_correct	n/a	1	1	congruent	358	n/a
-47	142.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
-48	150.0	1.0	incongruent_correct	n/a	1	2	incongruent	577	n/a
-49	152.5	1.0	congruent_correct	n/a	1	1	congruent	488	n/a
-50	155.0	1.0	incongruent_correct	n/a	1	2	incongruent	439	n/a
-51	157.5	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
-52	160.0	1.0	incongruent_correct	n/a	1	2	incongruent	501	n/a
-53	162.5	1.0	incongruent_correct	n/a	1	2	incongruent	548	n/a
-54	165.0	1.0	incongruent_correct	n/a	1	2	incongruent	466	n/a
-55	167.5	1.0	incongruent_correct	n/a	1	2	incongruent	450	n/a
-56	170.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
-57	172.5	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
-58	175.0	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
-59	177.5	1.0	congruent_correct	n/a	1	1	congruent	549	n/a
-60	185.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	618	n/a
-61	187.5	1.0	congruent_correct	n/a	1	1	congruent	512	n/a
-62	190.0	1.0	congruent_correct	n/a	1	1	congruent	424	n/a
-63	192.5	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
-64	195.0	1.0	incongruent_correct	n/a	1	2	incongruent	469	n/a
-65	197.5	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
-66	200.0	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
-67	202.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
-68	210.0	1.0	incongruent_correct	n/a	1	2	incongruent	622	n/a
-69	212.5	1.0	incongruent_correct	n/a	1	2	incongruent	533	n/a
-70	215.0	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
-71	217.5	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
-72	225.0	1.0	congruent_correct	n/a	1	1	congruent	607	n/a
-73	227.5	1.0	congruent_correct	n/a	1	1	congruent	407	n/a
-74	230.0	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
-75	232.5	1.0	congruent_correct	n/a	1	1	congruent	484	n/a
-76	235.0	1.0	incongruent_correct	n/a	1	2	incongruent	539	n/a
-77	237.5	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
-78	240.0	1.0	congruent_correct	n/a	1	1	congruent	537	n/a
-79	242.5	1.0	incongruent_correct	n/a	1	2	incongruent	511	n/a
-80	245.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
-81	247.5	1.0	congruent_correct	n/a	1	1	congruent	693	n/a
-82	250.0	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
-83	252.5	1.0	congruent_correct	n/a	1	1	congruent	555	n/a
-84	260.0	1.0	incongruent_correct	n/a	1	2	incongruent	607	n/a
-85	262.5	1.0	congruent_correct	n/a	1	1	congruent	535	n/a
-86	270.0	1.0	congruent_correct	n/a	1	1	congruent	499	n/a
-87	272.5	1.0	congruent_correct	n/a	1	1	congruent	403	n/a
-88	275.0	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
-89	277.5	1.0	congruent_correct	n/a	1	1	congruent	576	n/a
-90	285.0	1.0	congruent_correct	n/a	1	1	congruent	533	n/a
-91	287.5	1.0	incongruent_correct	n/a	1	2	incongruent	508	n/a
-92	290.0	1.0	congruent_correct	n/a	1	1	congruent	467	n/a
-93	292.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
-94	295.0	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
-95	297.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	0	n/a
+onset	duration	trial_type	congruent_incorrect	Unnamed: 1	Rsponse	StimVar	Stimulus	ResponseTime
+0.0	1.0	congruent_correct	n/a	1	1	congruent	492	n/a
+2.5	1.0	congruent_correct	n/a	1	1	congruent	388	n/a
+10.0	1.0	incongruent_correct	n/a	1	2	incongruent	529	n/a
+12.5	1.0	incongruent_correct	n/a	1	2	incongruent	615	n/a
+15.0	1.0	incongruent_correct	n/a	1	2	incongruent	487	n/a
+17.5	1.0	incongruent_correct	n/a	1	2	incongruent	477	n/a
+25.0	1.0	congruent_correct	n/a	1	1	congruent	730	n/a
+27.5	1.0	congruent_correct	n/a	1	1	congruent	338	n/a
+30.0	1.0	incongruent_correct	n/a	1	2	incongruent	504	n/a
+32.5	1.0	congruent_correct	n/a	1	1	congruent	615	n/a
+35.0	1.0	incongruent_correct	n/a	1	2	incongruent	469	n/a
+37.5	1.0	congruent_correct	n/a	1	1	congruent	605	n/a
+40.0	1.0	congruent_correct	n/a	1	1	congruent	515	n/a
+42.5	1.0	incongruent_correct	n/a	1	2	incongruent	530	n/a
+45.0	1.0	incongruent_correct	n/a	1	2	incongruent	432	n/a
+47.5	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+50.0	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
+52.5	1.0	incongruent_correct	n/a	1	2	incongruent	509	n/a
+60.0	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
+62.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+65.0	1.0	congruent_correct	n/a	1	1	congruent	352	n/a
+67.5	1.0	congruent_correct	n/a	1	1	congruent	382	n/a
+75.0	1.0	congruent_correct	n/a	1	1	congruent	563	n/a
+77.5	1.0	congruent_correct	n/a	1	1	congruent	435	n/a
+80.0	1.0	congruent_correct	n/a	1	1	congruent	353	n/a
+82.5	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
+85.0	1.0	incongruent_correct	n/a	1	2	incongruent	543	n/a
+87.5	1.0	congruent_correct	n/a	1	1	congruent	398	n/a
+90.0	1.0	incongruent_correct	n/a	1	2	incongruent	516	n/a
+92.5	1.0	congruent_correct	n/a	1	1	congruent	332	n/a
+95.0	1.0	congruent_correct	n/a	1	1	congruent	339	n/a
+97.5	1.0	incongruent_correct	n/a	1	2	incongruent	537	n/a
+100.0	1.0	congruent_correct	n/a	1	1	congruent	376	n/a
+102.5	1.0	incongruent_correct	n/a	1	2	incongruent	495	n/a
+105.0	1.0	incongruent_correct	n/a	1	2	incongruent	438	n/a
+107.5	1.0	incongruent_correct	n/a	1	2	incongruent	436	n/a
+110.0	1.0	congruent_correct	n/a	1	1	congruent	427	n/a
+112.5	1.0	congruent_correct	n/a	1	1	congruent	522	n/a
+120.0	1.0	congruent_correct	n/a	1	1	congruent	551	n/a
+122.5	1.0	congruent_correct	n/a	1	1	congruent	390	n/a
+125.0	1.0	congruent_correct	n/a	1	1	congruent	325	n/a
+127.5	1.0	congruent_correct	n/a	1	1	congruent	460	n/a
+130.0	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
+132.5	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
+135.0	1.0	congruent_correct	n/a	1	1	congruent	520	n/a
+137.5	1.0	incongruent_correct	n/a	1	2	incongruent	519	n/a
+140.0	1.0	congruent_correct	n/a	1	1	congruent	358	n/a
+142.5	1.0	incongruent_correct	n/a	1	2	incongruent	468	n/a
+150.0	1.0	incongruent_correct	n/a	1	2	incongruent	577	n/a
+152.5	1.0	congruent_correct	n/a	1	1	congruent	488	n/a
+155.0	1.0	incongruent_correct	n/a	1	2	incongruent	439	n/a
+157.5	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
+160.0	1.0	incongruent_correct	n/a	1	2	incongruent	501	n/a
+162.5	1.0	incongruent_correct	n/a	1	2	incongruent	548	n/a
+165.0	1.0	incongruent_correct	n/a	1	2	incongruent	466	n/a
+167.5	1.0	incongruent_correct	n/a	1	2	incongruent	450	n/a
+170.0	1.0	incongruent_correct	n/a	1	2	incongruent	496	n/a
+172.5	1.0	incongruent_correct	n/a	1	2	incongruent	503	n/a
+175.0	1.0	congruent_correct	n/a	1	1	congruent	389	n/a
+177.5	1.0	congruent_correct	n/a	1	1	congruent	549	n/a
+185.0	1.0	incongruent_incorrect	n/a	0	2	incongruent	618	n/a
+187.5	1.0	congruent_correct	n/a	1	1	congruent	512	n/a
+190.0	1.0	congruent_correct	n/a	1	1	congruent	424	n/a
+192.5	1.0	incongruent_correct	n/a	1	2	incongruent	558	n/a
+195.0	1.0	incongruent_correct	n/a	1	2	incongruent	469	n/a
+197.5	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
+200.0	1.0	incongruent_correct	n/a	1	2	incongruent	491	n/a
+202.5	1.0	congruent_correct	n/a	1	1	congruent	393	n/a
+210.0	1.0	incongruent_correct	n/a	1	2	incongruent	622	n/a
+212.5	1.0	incongruent_correct	n/a	1	2	incongruent	533	n/a
+215.0	1.0	congruent_correct	n/a	1	1	congruent	468	n/a
+217.5	1.0	incongruent_correct	n/a	1	2	incongruent	531	n/a
+225.0	1.0	congruent_correct	n/a	1	1	congruent	607	n/a
+227.5	1.0	congruent_correct	n/a	1	1	congruent	407	n/a
+230.0	1.0	congruent_correct	n/a	1	1	congruent	502	n/a
+232.5	1.0	congruent_correct	n/a	1	1	congruent	484	n/a
+235.0	1.0	incongruent_correct	n/a	1	2	incongruent	539	n/a
+237.5	1.0	congruent_correct	n/a	1	1	congruent	394	n/a
+240.0	1.0	congruent_correct	n/a	1	1	congruent	537	n/a
+242.5	1.0	incongruent_correct	n/a	1	2	incongruent	511	n/a
+245.0	1.0	incongruent_correct	n/a	1	2	incongruent	446	n/a
+247.5	1.0	congruent_correct	n/a	1	1	congruent	693	n/a
+250.0	1.0	incongruent_correct	n/a	1	2	incongruent	484	n/a
+252.5	1.0	congruent_correct	n/a	1	1	congruent	555	n/a
+260.0	1.0	incongruent_correct	n/a	1	2	incongruent	607	n/a
+262.5	1.0	congruent_correct	n/a	1	1	congruent	535	n/a
+270.0	1.0	congruent_correct	n/a	1	1	congruent	499	n/a
+272.5	1.0	congruent_correct	n/a	1	1	congruent	403	n/a
+275.0	1.0	incongruent_correct	n/a	1	2	incongruent	489	n/a
+277.5	1.0	congruent_correct	n/a	1	1	congruent	576	n/a
+285.0	1.0	congruent_correct	n/a	1	1	congruent	533	n/a
+287.5	1.0	incongruent_correct	n/a	1	2	incongruent	508	n/a
+290.0	1.0	congruent_correct	n/a	1	1	congruent	467	n/a
+292.5	1.0	incongruent_correct	n/a	1	2	incongruent	465	n/a
+295.0	1.0	incongruent_correct	n/a	1	2	incongruent	561	n/a
+297.5	1.0	incongruent_incorrect	n/a	0	2	incongruent	0	n/a


### PR DESCRIPTION
…and an incorrect first column containing event number (should be onset)

bids-validator returned First column of the events file must be named 'onset' (code: 20 - EVENTS_COLUMN_ONSET)

The number of columns was 10, whereas there are only 9 header labels. The header line started with a tab, suggesting that the first element was removed. Since the first column only contained event number (index), I removed it like this

```
for file in `find . -type f -name \*events.tsv` ; do cut -f 2-20 $file > out && mv out $file ; done
``` 
 