### PR TITLE
Fix embla

### DIFF
--- a/eeg_sleep/sub-01/eeg/sub-01_task-sleep_channels.tsv
+++ b/eeg_sleep/sub-01/eeg/sub-01_task-sleep_channels.tsv
@@ -5,7 +5,7 @@ Chin	EMG	uV
 Cz	EEG	uV
 E1	EEG	uV
 E2	EEG	uV
-EKG	EEG	uV
+EKG	ECG	uV
 F3	EEG	uV
 F4	EEG	uV
 Fz	EEG	uV

--- a/eeg_sleep/sub-01/eeg/sub-01_task-sleep_eeg.json
+++ b/eeg_sleep/sub-01/eeg/sub-01_task-sleep_eeg.json
@@ -6,5 +6,6 @@
   "EMGChannelCount": 1,
   "ECGChannelCount": 1,
   "MiscChannelCount": 3,
-  "ManufacturersAmplifierModelName": "EMBLA"
+  "Manufacturer": "Natus",
+  "ManufacturersModelName": "S4500 PSG Amplifier"
 }

--- a/eeg_sleep/sub-01/eeg/sub-01_task-sleep_eeg.json
+++ b/eeg_sleep/sub-01/eeg/sub-01_task-sleep_eeg.json
@@ -1,7 +1,8 @@
 {
   "TaskName": "sleep",
-  "EEGSamplingFrequency": 250,
+  "SamplingFrequency": 250,
   "EEGChannelCount": 16,
+  "EOGChannelCount": 0,
   "EMGChannelCount": 1,
   "ECGChannelCount": 1,
   "MiscChannelCount": 3,


### PR DESCRIPTION
fixes #81 

besides these fixes the reformatting of the embla dataset looks compliant to me.

However, if we decide to allow for types "GRD" and "REF" in the channels.tsv, then we'd have to adjust that again (i.e., the current type of REF in _channels.tsv is EEG ... but should be changed to REF, if we should allow that type)
