### PR TITLE
Fix sleep

### DIFF
--- a/eeg_sleep/sub-01/eeg/sub-01_task-sleep_eeg.json
+++ b/eeg_sleep/sub-01/eeg/sub-01_task-sleep_eeg.json
@@ -8,5 +8,6 @@
   "MiscChannelCount": 3,
   "Manufacturer": "Natus",
   "ManufacturersModelName": "S4500 PSG Amplifier",
-  "EEGReference": "unipolar using electrode 'REF', placement unknown"
+  "EEGReference": "unipolar using electrode 'REF', placement unknown",
+  "PowerLineFrequency": 50
 }


### PR DESCRIPTION
adding a missing required parameter.

...  assuming eeg_sleep data was collected in Europe (i.e., 50Hz PowerLineFrequency). Perhaps @ChristophePhillips can confirm.