### PR TITLE
fix acq_time formats for ds000247, ds000117, and ds000246

### DIFF
--- a/ds000117/sub-01/ses-meg/sub-01_ses-meg_scans.tsv
+++ b/ds000117/sub-01/ses-meg/sub-01_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-01_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T12:04:14
-meg/sub-01_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T12:17:17
-meg/sub-01_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:27:22
-meg/sub-01_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:37:33
-meg/sub-01_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:47:23
-meg/sub-01_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T12:58:06
+meg/sub-01_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T12:04:14
+meg/sub-01_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T12:17:17
+meg/sub-01_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T12:27:22
+meg/sub-01_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T12:37:33
+meg/sub-01_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T12:47:23
+meg/sub-01_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T12:58:06

--- a/ds000117/sub-01/ses-meg/sub-01_ses-meg_scans.tsv
+++ b/ds000117/sub-01/ses-meg/sub-01_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-01_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T12:04:14
-meg/sub-01_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T12:17:17
-meg/sub-01_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T12:27:22
-meg/sub-01_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T12:37:33
-meg/sub-01_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T12:47:23
-meg/sub-01_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T12:58:06
+meg/sub-01_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T12:04:14
+meg/sub-01_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T12:17:17
+meg/sub-01_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:27:22
+meg/sub-01_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:37:33
+meg/sub-01_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:47:23
+meg/sub-01_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T12:58:06

--- a/ds000117/sub-02/ses-meg/sub-02_ses-meg_scans.tsv
+++ b/ds000117/sub-02/ses-meg/sub-02_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-02_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T09:49:10
-meg/sub-02_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T10:01:34
-meg/sub-02_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T10:11:25
-meg/sub-02_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T10:20:51
-meg/sub-02_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T10:31:09
-meg/sub-02_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T10:41:15
+meg/sub-02_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T09:49:10
+meg/sub-02_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T10:01:34
+meg/sub-02_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T10:11:25
+meg/sub-02_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T10:20:51
+meg/sub-02_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T10:31:09
+meg/sub-02_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T10:41:15

--- a/ds000117/sub-02/ses-meg/sub-02_ses-meg_scans.tsv
+++ b/ds000117/sub-02/ses-meg/sub-02_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-02_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T09:49:10
-meg/sub-02_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T10:01:34
-meg/sub-02_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T10:11:25
-meg/sub-02_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T10:20:51
-meg/sub-02_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T10:31:09
-meg/sub-02_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T10:41:15
+meg/sub-02_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T09:49:10
+meg/sub-02_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T10:01:34
+meg/sub-02_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T10:11:25
+meg/sub-02_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T10:20:51
+meg/sub-02_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T10:31:09
+meg/sub-02_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T10:41:15

--- a/ds000117/sub-03/ses-meg/sub-03_ses-meg_scans.tsv
+++ b/ds000117/sub-03/ses-meg/sub-03_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-03_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T11:44:28
-meg/sub-03_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T12:00:27
-meg/sub-03_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T12:11:00
-meg/sub-03_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T12:21:17
-meg/sub-03_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T12:31:54
-meg/sub-03_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T12:42:30
+meg/sub-03_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T11:44:28
+meg/sub-03_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T12:00:27
+meg/sub-03_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:11:00
+meg/sub-03_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:21:17
+meg/sub-03_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:31:54
+meg/sub-03_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T12:42:30

--- a/ds000117/sub-03/ses-meg/sub-03_ses-meg_scans.tsv
+++ b/ds000117/sub-03/ses-meg/sub-03_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-03_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T11:44:28
-meg/sub-03_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T12:00:27
-meg/sub-03_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:11:00
-meg/sub-03_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:21:17
-meg/sub-03_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:31:54
-meg/sub-03_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T12:42:30
+meg/sub-03_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T11:44:28
+meg/sub-03_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T12:00:27
+meg/sub-03_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T12:11:00
+meg/sub-03_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T12:21:17
+meg/sub-03_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T12:31:54
+meg/sub-03_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T12:42:30

--- a/ds000117/sub-04/ses-meg/sub-04_ses-meg_scans.tsv
+++ b/ds000117/sub-04/ses-meg/sub-04_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-04_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T12:26:31
-meg/sub-04_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T12:35:52
-meg/sub-04_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:47:36
-meg/sub-04_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:57:06
-meg/sub-04_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T13:06:38
-meg/sub-04_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T13:16:44
+meg/sub-04_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T12:26:31
+meg/sub-04_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T12:35:52
+meg/sub-04_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T12:47:36
+meg/sub-04_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T12:57:06
+meg/sub-04_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T13:06:38
+meg/sub-04_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T13:16:44

--- a/ds000117/sub-04/ses-meg/sub-04_ses-meg_scans.tsv
+++ b/ds000117/sub-04/ses-meg/sub-04_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-04_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T12:26:31
-meg/sub-04_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T12:35:52
-meg/sub-04_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T12:47:36
-meg/sub-04_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T12:57:06
-meg/sub-04_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T13:06:38
-meg/sub-04_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T13:16:44
+meg/sub-04_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T12:26:31
+meg/sub-04_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T12:35:52
+meg/sub-04_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:47:36
+meg/sub-04_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:57:06
+meg/sub-04_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T13:06:38
+meg/sub-04_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T13:16:44

--- a/ds000117/sub-05/ses-meg/sub-05_ses-meg_scans.tsv
+++ b/ds000117/sub-05/ses-meg/sub-05_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-05_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T10:05:03
-meg/sub-05_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T10:15:48
-meg/sub-05_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T10:26:40
-meg/sub-05_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T10:36:30
-meg/sub-05_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T10:46:28
-meg/sub-05_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T10:56:09
+meg/sub-05_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T10:05:03
+meg/sub-05_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T10:15:48
+meg/sub-05_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T10:26:40
+meg/sub-05_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T10:36:30
+meg/sub-05_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T10:46:28
+meg/sub-05_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T10:56:09

--- a/ds000117/sub-05/ses-meg/sub-05_ses-meg_scans.tsv
+++ b/ds000117/sub-05/ses-meg/sub-05_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-05_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T10:05:03
-meg/sub-05_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T10:15:48
-meg/sub-05_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T10:26:40
-meg/sub-05_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T10:36:30
-meg/sub-05_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T10:46:28
-meg/sub-05_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T10:56:09
+meg/sub-05_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T10:05:03
+meg/sub-05_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T10:15:48
+meg/sub-05_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T10:26:40
+meg/sub-05_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T10:36:30
+meg/sub-05_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T10:46:28
+meg/sub-05_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T10:56:09

--- a/ds000117/sub-06/ses-meg/sub-06_ses-meg_scans.tsv
+++ b/ds000117/sub-06/ses-meg/sub-06_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-06_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T11:45:08
-meg/sub-06_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T11:56:02
-meg/sub-06_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T12:06:08
-meg/sub-06_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T12:15:48
-meg/sub-06_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T12:26:12
-meg/sub-06_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T12:36:02
+meg/sub-06_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T11:45:08
+meg/sub-06_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T11:56:02
+meg/sub-06_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:06:08
+meg/sub-06_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:15:48
+meg/sub-06_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:26:12
+meg/sub-06_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T12:36:02

--- a/ds000117/sub-06/ses-meg/sub-06_ses-meg_scans.tsv
+++ b/ds000117/sub-06/ses-meg/sub-06_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-06_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T11:45:08
-meg/sub-06_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T11:56:02
-meg/sub-06_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:06:08
-meg/sub-06_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:15:48
-meg/sub-06_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:26:12
-meg/sub-06_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T12:36:02
+meg/sub-06_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T11:45:08
+meg/sub-06_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T11:56:02
+meg/sub-06_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T12:06:08
+meg/sub-06_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T12:15:48
+meg/sub-06_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T12:26:12
+meg/sub-06_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T12:36:02

--- a/ds000117/sub-07/ses-meg/sub-07_ses-meg_scans.tsv
+++ b/ds000117/sub-07/ses-meg/sub-07_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-07_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T10:03:43
-meg/sub-07_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T10:14:53
-meg/sub-07_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T10:26:05
-meg/sub-07_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T10:36:33
-meg/sub-07_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T10:49:57
-meg/sub-07_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T11:00:02
+meg/sub-07_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T10:03:43
+meg/sub-07_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T10:14:53
+meg/sub-07_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T10:26:05
+meg/sub-07_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T10:36:33
+meg/sub-07_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T10:49:57
+meg/sub-07_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T11:00:02

--- a/ds000117/sub-07/ses-meg/sub-07_ses-meg_scans.tsv
+++ b/ds000117/sub-07/ses-meg/sub-07_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-07_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T10:03:43
-meg/sub-07_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T10:14:53
-meg/sub-07_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T10:26:05
-meg/sub-07_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T10:36:33
-meg/sub-07_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T10:49:57
-meg/sub-07_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T11:00:02
+meg/sub-07_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T10:03:43
+meg/sub-07_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T10:14:53
+meg/sub-07_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T10:26:05
+meg/sub-07_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T10:36:33
+meg/sub-07_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T10:49:57
+meg/sub-07_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T11:00:02

--- a/ds000117/sub-08/ses-meg/sub-08_ses-meg_scans.tsv
+++ b/ds000117/sub-08/ses-meg/sub-08_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-08_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T14:22:50
-meg/sub-08_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T14:35:48
-meg/sub-08_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T14:46:12
-meg/sub-08_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T14:56:06
-meg/sub-08_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T15:07:22
-meg/sub-08_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T15:17:59
+meg/sub-08_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T14:22:50
+meg/sub-08_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T14:35:48
+meg/sub-08_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T14:46:12
+meg/sub-08_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T14:56:06
+meg/sub-08_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T15:07:22
+meg/sub-08_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T15:17:59

--- a/ds000117/sub-08/ses-meg/sub-08_ses-meg_scans.tsv
+++ b/ds000117/sub-08/ses-meg/sub-08_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-08_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T14:22:50
-meg/sub-08_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T14:35:48
-meg/sub-08_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T14:46:12
-meg/sub-08_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T14:56:06
-meg/sub-08_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T15:07:22
-meg/sub-08_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T15:17:59
+meg/sub-08_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T14:22:50
+meg/sub-08_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T14:35:48
+meg/sub-08_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T14:46:12
+meg/sub-08_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T14:56:06
+meg/sub-08_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T15:07:22
+meg/sub-08_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T15:17:59

--- a/ds000117/sub-09/ses-meg/sub-09_ses-meg_scans.tsv
+++ b/ds000117/sub-09/ses-meg/sub-09_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-09_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T14:13:06
-meg/sub-09_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T14:24:04
-meg/sub-09_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T14:36:43
-meg/sub-09_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T14:46:40
-meg/sub-09_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T14:58:49
-meg/sub-09_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T15:08:07
+meg/sub-09_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T14:13:06
+meg/sub-09_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T14:24:04
+meg/sub-09_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T14:36:43
+meg/sub-09_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T14:46:40
+meg/sub-09_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T14:58:49
+meg/sub-09_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T15:08:07

--- a/ds000117/sub-09/ses-meg/sub-09_ses-meg_scans.tsv
+++ b/ds000117/sub-09/ses-meg/sub-09_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-09_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T14:13:06
-meg/sub-09_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T14:24:04
-meg/sub-09_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T14:36:43
-meg/sub-09_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T14:46:40
-meg/sub-09_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T14:58:49
-meg/sub-09_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T15:08:07
+meg/sub-09_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T14:13:06
+meg/sub-09_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T14:24:04
+meg/sub-09_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T14:36:43
+meg/sub-09_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T14:46:40
+meg/sub-09_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T14:58:49
+meg/sub-09_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T15:08:07

--- a/ds000117/sub-10/ses-meg/sub-10_ses-meg_scans.tsv
+++ b/ds000117/sub-10/ses-meg/sub-10_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-10_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T16:22:51
-meg/sub-10_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T16:35:21
-meg/sub-10_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T16:45:42
-meg/sub-10_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T16:55:03
-meg/sub-10_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T17:05:13
-meg/sub-10_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T17:15:57
+meg/sub-10_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T16:22:51
+meg/sub-10_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T16:35:21
+meg/sub-10_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T16:45:42
+meg/sub-10_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T16:55:03
+meg/sub-10_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T17:05:13
+meg/sub-10_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T17:15:57

--- a/ds000117/sub-10/ses-meg/sub-10_ses-meg_scans.tsv
+++ b/ds000117/sub-10/ses-meg/sub-10_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-10_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T16:22:51
-meg/sub-10_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T16:35:21
-meg/sub-10_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T16:45:42
-meg/sub-10_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T16:55:03
-meg/sub-10_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T17:05:13
-meg/sub-10_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T17:15:57
+meg/sub-10_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T16:22:51
+meg/sub-10_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T16:35:21
+meg/sub-10_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T16:45:42
+meg/sub-10_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T16:55:03
+meg/sub-10_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T17:05:13
+meg/sub-10_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T17:15:57

--- a/ds000117/sub-11/ses-meg/sub-11_ses-meg_scans.tsv
+++ b/ds000117/sub-11/ses-meg/sub-11_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-11_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T11:44:27
-meg/sub-11_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T11:56:16
-meg/sub-11_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:05:50
-meg/sub-11_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:15:35
-meg/sub-11_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:26:01
-meg/sub-11_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T12:35:44
+meg/sub-11_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T11:44:27
+meg/sub-11_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T11:56:16
+meg/sub-11_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T12:05:50
+meg/sub-11_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T12:15:35
+meg/sub-11_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T12:26:01
+meg/sub-11_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T12:35:44

--- a/ds000117/sub-11/ses-meg/sub-11_ses-meg_scans.tsv
+++ b/ds000117/sub-11/ses-meg/sub-11_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-11_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T11:44:27
-meg/sub-11_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T11:56:16
-meg/sub-11_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T12:05:50
-meg/sub-11_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T12:15:35
-meg/sub-11_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T12:26:01
-meg/sub-11_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T12:35:44
+meg/sub-11_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T11:44:27
+meg/sub-11_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T11:56:16
+meg/sub-11_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:05:50
+meg/sub-11_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:15:35
+meg/sub-11_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:26:01
+meg/sub-11_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T12:35:44

--- a/ds000117/sub-12/ses-meg/sub-12_ses-meg_scans.tsv
+++ b/ds000117/sub-12/ses-meg/sub-12_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-12_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T16:40:30
-meg/sub-12_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T16:52:13
-meg/sub-12_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T17:03:05
-meg/sub-12_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T17:12:33
-meg/sub-12_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T17:22:24
-meg/sub-12_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T17:33:45
+meg/sub-12_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T16:40:30
+meg/sub-12_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T16:52:13
+meg/sub-12_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T17:03:05
+meg/sub-12_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T17:12:33
+meg/sub-12_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T17:22:24
+meg/sub-12_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T17:33:45

--- a/ds000117/sub-12/ses-meg/sub-12_ses-meg_scans.tsv
+++ b/ds000117/sub-12/ses-meg/sub-12_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-12_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T16:40:30
-meg/sub-12_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T16:52:13
-meg/sub-12_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T17:03:05
-meg/sub-12_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T17:12:33
-meg/sub-12_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T17:22:24
-meg/sub-12_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T17:33:45
+meg/sub-12_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T16:40:30
+meg/sub-12_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T16:52:13
+meg/sub-12_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T17:03:05
+meg/sub-12_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T17:12:33
+meg/sub-12_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T17:22:24
+meg/sub-12_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T17:33:45

--- a/ds000117/sub-13/ses-meg/sub-13_ses-meg_scans.tsv
+++ b/ds000117/sub-13/ses-meg/sub-13_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-13_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T11:58:19
-meg/sub-13_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T12:15:06
-meg/sub-13_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:26:39
-meg/sub-13_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:44:30
-meg/sub-13_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:56:00
-meg/sub-13_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T13:06:28
+meg/sub-13_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T11:58:19
+meg/sub-13_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T12:15:06
+meg/sub-13_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T12:26:39
+meg/sub-13_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T12:44:30
+meg/sub-13_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T12:56:00
+meg/sub-13_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T13:06:28

--- a/ds000117/sub-13/ses-meg/sub-13_ses-meg_scans.tsv
+++ b/ds000117/sub-13/ses-meg/sub-13_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-13_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T11:58:19
-meg/sub-13_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T12:15:06
-meg/sub-13_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T12:26:39
-meg/sub-13_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T12:44:30
-meg/sub-13_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T12:56:00
-meg/sub-13_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T13:06:28
+meg/sub-13_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T11:58:19
+meg/sub-13_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T12:15:06
+meg/sub-13_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:26:39
+meg/sub-13_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:44:30
+meg/sub-13_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:56:00
+meg/sub-13_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T13:06:28

--- a/ds000117/sub-14/ses-meg/sub-14_ses-meg_scans.tsv
+++ b/ds000117/sub-14/ses-meg/sub-14_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-14_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T16:48:45
-meg/sub-14_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T17:03:40
-meg/sub-14_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T17:14:10
-meg/sub-14_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T17:24:37
-meg/sub-14_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T17:34:49
-meg/sub-14_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T17:44:53
+meg/sub-14_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T16:48:45
+meg/sub-14_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T17:03:40
+meg/sub-14_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T17:14:10
+meg/sub-14_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T17:24:37
+meg/sub-14_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T17:34:49
+meg/sub-14_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T17:44:53

--- a/ds000117/sub-14/ses-meg/sub-14_ses-meg_scans.tsv
+++ b/ds000117/sub-14/ses-meg/sub-14_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-14_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T16:48:45
-meg/sub-14_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T17:03:40
-meg/sub-14_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T17:14:10
-meg/sub-14_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T17:24:37
-meg/sub-14_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T17:34:49
-meg/sub-14_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T17:44:53
+meg/sub-14_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T16:48:45
+meg/sub-14_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T17:03:40
+meg/sub-14_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T17:14:10
+meg/sub-14_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T17:24:37
+meg/sub-14_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T17:34:49
+meg/sub-14_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T17:44:53

--- a/ds000117/sub-15/ses-meg/sub-15_ses-meg_scans.tsv
+++ b/ds000117/sub-15/ses-meg/sub-15_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-15_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T12:04:19
-meg/sub-15_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T12:13:55
-meg/sub-15_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T12:23:39
-meg/sub-15_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T12:33:12
-meg/sub-15_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T12:42:46
-meg/sub-15_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T12:54:19
+meg/sub-15_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T12:04:19
+meg/sub-15_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T12:13:55
+meg/sub-15_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:23:39
+meg/sub-15_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:33:12
+meg/sub-15_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:42:46
+meg/sub-15_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T12:54:19

--- a/ds000117/sub-15/ses-meg/sub-15_ses-meg_scans.tsv
+++ b/ds000117/sub-15/ses-meg/sub-15_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-15_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T12:04:19
-meg/sub-15_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T12:13:55
-meg/sub-15_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T12:23:39
-meg/sub-15_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T12:33:12
-meg/sub-15_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T12:42:46
-meg/sub-15_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T12:54:19
+meg/sub-15_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T12:04:19
+meg/sub-15_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T12:13:55
+meg/sub-15_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T12:23:39
+meg/sub-15_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T12:33:12
+meg/sub-15_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T12:42:46
+meg/sub-15_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T12:54:19

--- a/ds000117/sub-16/ses-meg/sub-16_ses-meg_scans.tsv
+++ b/ds000117/sub-16/ses-meg/sub-16_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-16_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T16:25:42
-meg/sub-16_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T16:34:58
-meg/sub-16_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T16:44:47
-meg/sub-16_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T16:54:37
-meg/sub-16_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T17:04:21
-meg/sub-16_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T17:14:26
+meg/sub-16_ses-meg_task-facerecognition_run-01_meg.fif	1801-05-05T16:25:42
+meg/sub-16_ses-meg_task-facerecognition_run-02_meg.fif	1801-05-05T16:34:58
+meg/sub-16_ses-meg_task-facerecognition_run-03_meg.fif	1801-05-05T16:44:47
+meg/sub-16_ses-meg_task-facerecognition_run-04_meg.fif	1801-05-05T16:54:37
+meg/sub-16_ses-meg_task-facerecognition_run-05_meg.fif	1801-05-05T17:04:21
+meg/sub-16_ses-meg_task-facerecognition_run-06_meg.fif	1801-05-05T17:14:26

--- a/ds000117/sub-16/ses-meg/sub-16_ses-meg_scans.tsv
+++ b/ds000117/sub-16/ses-meg/sub-16_ses-meg_scans.tsv
@@ -1,7 +1,7 @@
 filename	acq_time
-meg/sub-16_ses-meg_task-facerecognition_run-01_meg.fif	##-##-##T16:25:42
-meg/sub-16_ses-meg_task-facerecognition_run-02_meg.fif	##-##-##T16:34:58
-meg/sub-16_ses-meg_task-facerecognition_run-03_meg.fif	##-##-##T16:44:47
-meg/sub-16_ses-meg_task-facerecognition_run-04_meg.fif	##-##-##T16:54:37
-meg/sub-16_ses-meg_task-facerecognition_run-05_meg.fif	##-##-##T17:04:21
-meg/sub-16_ses-meg_task-facerecognition_run-06_meg.fif	##-##-##T17:14:26
+meg/sub-16_ses-meg_task-facerecognition_run-01_meg.fif	2018-05-05T16:25:42
+meg/sub-16_ses-meg_task-facerecognition_run-02_meg.fif	2018-05-05T16:34:58
+meg/sub-16_ses-meg_task-facerecognition_run-03_meg.fif	2018-05-05T16:44:47
+meg/sub-16_ses-meg_task-facerecognition_run-04_meg.fif	2018-05-05T16:54:37
+meg/sub-16_ses-meg_task-facerecognition_run-05_meg.fif	2018-05-05T17:04:21
+meg/sub-16_ses-meg_task-facerecognition_run-06_meg.fif	2018-05-05T17:14:26

--- a/ds000117/sub-emptyroom/ses-20090409/sub-emptyroom_ses-20090409_scans.tsv
+++ b/ds000117/sub-emptyroom/ses-20090409/sub-emptyroom_ses-20090409_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-20090409_task-noise_meg.fif	##-##-##T11:05:49
+meg/sub-emptyroom_ses-20090409_task-noise_meg.fif	2009-04-09T11:05:49

--- a/ds000117/sub-emptyroom/ses-20090506/sub-emptyroom_ses-20090506_scans.tsv
+++ b/ds000117/sub-emptyroom/ses-20090506/sub-emptyroom_ses-20090506_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-20090506_task-noise_meg.fif	##-##-##T14:51:49
+meg/sub-emptyroom_ses-20090506_task-noise_meg.fif	2009-05-06T14:51:49

--- a/ds000117/sub-emptyroom/ses-20090511/sub-emptyroom_ses-20090511_scans.tsv
+++ b/ds000117/sub-emptyroom/ses-20090511/sub-emptyroom_ses-20090511_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-20090511_task-noise_meg.fif	##-##-##T09:39:23
+meg/sub-emptyroom_ses-20090511_task-noise_meg.fif	2009-05-11T09:39:23

--- a/ds000117/sub-emptyroom/ses-20090515/sub-emptyroom_ses-20090515_scans.tsv
+++ b/ds000117/sub-emptyroom/ses-20090515/sub-emptyroom_ses-20090515_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-20090515_task-noise_meg.fif	##-##-##T15:52:30
+meg/sub-emptyroom_ses-20090515_task-noise_meg.fif	2009-05-15T15:52:30

--- a/ds000117/sub-emptyroom/ses-20090518/sub-emptyroom_ses-20090518_scans.tsv
+++ b/ds000117/sub-emptyroom/ses-20090518/sub-emptyroom_ses-20090518_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-20090518_task-noise_meg.fif	##-##-##T09:33:15
+meg/sub-emptyroom_ses-20090518_task-noise_meg.fif	2009-05-18T09:33:15

--- a/ds000117/sub-emptyroom/ses-20090601/sub-emptyroom_ses-20090601_scans.tsv
+++ b/ds000117/sub-emptyroom/ses-20090601/sub-emptyroom_ses-20090601_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-20090601_task-noise_meg.fif	##-##-##T10:05:18
+meg/sub-emptyroom_ses-20090601_task-noise_meg.fif	2009-06-01T10:05:18

--- a/ds000117/sub-emptyroom/ses-20091126/sub-emptyroom_ses-20091126_scans.tsv
+++ b/ds000117/sub-emptyroom/ses-20091126/sub-emptyroom_ses-20091126_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-20091126_task-noise_meg.fif	##-##-##T15:39:18
+meg/sub-emptyroom_ses-20091126_task-noise_meg.fif	2009-11-26T15:39:18

--- a/ds000117/sub-emptyroom/ses-20091208/sub-emptyroom_ses-20091208_scans.tsv
+++ b/ds000117/sub-emptyroom/ses-20091208/sub-emptyroom_ses-20091208_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-20091208_task-noise_meg.fif	##-##-##T09:54:18
+meg/sub-emptyroom_ses-20091208_task-noise_meg.fif	2009-12-08T09:54:18

--- a/ds000246/sub-0001/sub-0001_scans.tsv
+++ b/ds000246/sub-0001/sub-0001_scans.tsv
@@ -1,3 +1,3 @@
 filename	acq_time
-meg/sub-0001_task-AEF_run-01_meg.ds	18000101T094300
-meg/sub-0001_task-AEF_run-02_meg.ds	18000101T095100
+meg/sub-0001_task-AEF_run-01_meg.ds	1800-01-01T09:43:00
+meg/sub-0001_task-AEF_run-02_meg.ds	1800-01-01T09:51:00

--- a/ds000246/sub-emptyroom/sub-emptyroom_scans.tsv
+++ b/ds000246/sub-emptyroom/sub-emptyroom_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_task-noise_run-01_meg.ds	18000101T080200
+meg/sub-emptyroom_task-noise_run-01_meg.ds	1800-01-01T08:02:00

--- a/ds000247/sub-0002/ses-0001/sub-0002_ses-0001_scans.tsv
+++ b/ds000247/sub-0002/ses-0001/sub-0002_ses-0001_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-0002_ses-0001_task-rest_run-01_meg.ds	18901014T123300
+meg/sub-0002_ses-0001_task-rest_run-01_meg.ds	1890-10-14T12:33:00

--- a/ds000247/sub-0003/ses-0001/sub-0003_ses-0001_scans.tsv
+++ b/ds000247/sub-0003/ses-0001/sub-0003_ses-0001_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-0003_ses-0001_task-rest_run-01_meg.ds	18901015T174200
+meg/sub-0003_ses-0001_task-rest_run-01_meg.ds	1890-10-15T17:42:00

--- a/ds000247/sub-0004/ses-0001/sub-0004_ses-0001_scans.tsv
+++ b/ds000247/sub-0004/ses-0001/sub-0004_ses-0001_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-0004_ses-0001_task-rest_run-01_meg.ds	18910303T144200
+meg/sub-0004_ses-0001_task-rest_run-01_meg.ds	1891-03-03T14:42:00

--- a/ds000247/sub-0006/ses-0001/sub-0006_ses-0001_scans.tsv
+++ b/ds000247/sub-0006/ses-0001/sub-0006_ses-0001_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-0006_ses-0001_task-rest_run-01_meg.ds	18910512T104300
+meg/sub-0006_ses-0001_task-rest_run-01_meg.ds	1891-05-12T10:43:00

--- a/ds000247/sub-0007/ses-0001/sub-0007_ses-0001_scans.tsv
+++ b/ds000247/sub-0007/ses-0001/sub-0007_ses-0001_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-0007_ses-0001_task-rest_run-01_meg.ds	18910228T154000
+meg/sub-0007_ses-0001_task-rest_run-01_meg.ds	1891-02-28T15:40:00

--- a/ds000247/sub-emptyroom/ses-18901014/sub-emptyroom_ses-18901014_scans.tsv
+++ b/ds000247/sub-emptyroom/ses-18901014/sub-emptyroom_ses-18901014_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-18901014_task-noise_run-01_meg.ds	00191203T100900
+meg/sub-emptyroom_ses-18901014_task-noise_run-01_meg.ds	1890-10-14T10:09:00

--- a/ds000247/sub-emptyroom/ses-18901015/sub-emptyroom_ses-18901015_scans.tsv
+++ b/ds000247/sub-emptyroom/ses-18901015/sub-emptyroom_ses-18901015_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-18901015_task-noise_run-01_meg.ds	00201202T164800
+meg/sub-emptyroom_ses-18901015_task-noise_run-01_meg.ds	1890-10-15:48:00

--- a/ds000247/sub-emptyroom/ses-18910228/sub-emptyroom_ses-18910228_scans.tsv
+++ b/ds000247/sub-emptyroom/ses-18910228/sub-emptyroom_ses-18910228_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-18910228_task-noise_run-01_meg.ds	18910228T145000
+meg/sub-emptyroom_ses-18910228_task-noise_run-01_meg.ds	1891-02-28T14:50:00

--- a/ds000247/sub-emptyroom/ses-18910303/sub-emptyroom_ses-18910303_scans.tsv
+++ b/ds000247/sub-emptyroom/ses-18910303/sub-emptyroom_ses-18910303_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-18910303_task-noise_run-01_meg.ds	18910303T140400
+meg/sub-emptyroom_ses-18910303_task-noise_run-01_meg.ds	1891-03-03T14:04:00

--- a/ds000247/sub-emptyroom/ses-18910512/sub-emptyroom_ses-18910512_scans.tsv
+++ b/ds000247/sub-emptyroom/ses-18910512/sub-emptyroom_ses-18910512_scans.tsv
@@ -1,2 +1,2 @@
 filename	acq_time
-meg/sub-emptyroom_ses-18910512_task-noise_run-01_meg.ds	18910512T114600
+meg/sub-emptyroom_ses-18910512_task-noise_run-01_meg.ds	1891-05-12T11:46:00


### PR DESCRIPTION
acq_time should be in the format YYYY-MM-DDTHH:mm:ss for _scans.tsv files. this pr fixes that for example datasets with a file of this type.