### PR TITLE
Remove mentioning of --config.ignore=99 as not part of the bids-validator(-deno)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,7 @@ Just run the validator as follows (using the `eeg_matchingpennies` dataset as an
 example, and assuming you are in a command line at the root of the
 `bids-examples` repository):
 
-`bids-validator eeg_matchingpennies --config.ignore=99`
-
-The `--config.ignore=99` "flag" tells the bids-validator to ignore empty data
-files rather than to report the "empty file" error .
+`bids-validator eeg_matchingpennies`
 
 For datasets that contain NIfTI `.nii` files, you also need to add the
 `ignoreNiftiHeaders` flag to the `bids-validator` call, to suppress the issue
@@ -57,7 +54,7 @@ that NIfTI headers are not found.
 
 For example:
 
-`bids-validator ds003 --config.ignore=99 --ignoreNiftiHeaders`
+`bids-validator ds003 --ignoreNiftiHeaders`
 
 ### Validating all examples
 


### PR DESCRIPTION
    ❯ bids-validator-deno ds003 --config.ignore=99 --ignoreNiftiHeaders

    Usage:   bids-validator <dataset_directory>
    Version: 2.4.1

    Description:

      This tool checks if a dataset in a given directory is compatible with the Brain Imaging Data Structure specification. To learn more about Brain
      Imaging Data Structure visit http://bids.neuroimaging.io

    Options:

      -h, --help                                - Show this help.
      -V, --version                             - Show the version number for this program.
      --json                                    - [Deprecated] Use --format json instead. Output machine
                                                  readable JSON
      --format               <format>           - Output format: text (default), json, or json_pp              (Default: "text", Values: "text", "json",
                                                  (pretty-printed JSON)                                        "json_pp")
      -s, --schema           <URL-or-tag>       - Specify a schema version to use for validation
      -c, --config           <file>             - Path to a JSON configuration file
      --max-rows             <nrows>            - Maximum number of rows to validate in TSVs. Use 0 to         (Default: 1000)
                                                  validate headers only. Use -1 to validate all.
      -v, --verbose                             - Log more extensive information about issues
      --ignoreWarnings                          - Disregard non-critical issues
      --ignoreNiftiHeaders                      - Disregard NIfTI header content during validation
      --debug                <level>            - Enable debug output                                          (Default: "ERROR", Values: "NOTSET",
                                                                                                               "DEBUG", "INFO", "WARN", "ERROR",
                                                                                                               "CRITICAL")
      --filenameMode                            - Enable filename checks for newline separated filenames read
                                                  from stdin
      --datasetTypes         <datasetTypes>     - Permitted dataset types to validate against (default: all)   (Default: [], Values: "raw", "derivative",
                                                                                                               "study")
      --blacklistModalities  <modalities>       - Array of modalities to error on if detected.                 (Default: [], Values: "mri", "eeg", "emg",
                                                                                                               "ieeg", "meg", "beh", "pet", "micr",
                                                                                                               "motion", "nirs", "mrs")
      -r, --recursive                           - Validate datasets found in derivatives directories in
                                                  addition to root dataset
      -p, --prune                               - Prune derivatives and sourcedata directories on load
                                                  (disables -r and will underestimate dataset size)
      -o, --outfile          <file>             - File to write validation results to.
      --preferredRemote      <preferredRemote>  - Name of the preferred git-annex remote for accessing remote
                                                  data (experimental)
      --color, --no-color    [color]            - Enable/disable color output (defaults to detected support)   (Default: true)

      error: Unknown option "--config.ignore". Did you mean option "--config"?

<!-- New examples often relate to in-progress changes to the specification or validator. Link to the relevant PRs, if any. -->
<!-- Accepted formats: PR number (e.g., 123), GitHub shorthand (e.g., bids-standard/bids-specification#123), or full URL -->

- BIDS Specification PR: NONE
- BIDS Validator PR: NONE
- TODOs:
  - [ ] ...

<!-- PLEASE READ AND DELETE THE TEXT BELOW BEFORE OPENING THE PULL REQUEST -->

See the [CONTRIBUTING](https://github.com/bids-standard/bids-examples/blob/master/CONTRIBUTING.md) guide. Specifically:

- Please keep the title of your Pull Request (PR) short but informative - it will appear in the changelog.

