### PR TITLE
DOC: fix up specification of Units for genetics_ukbb to be years

### DIFF
--- a/genetics_ukbb/participants.json
+++ b/genetics_ukbb/participants.json
@@ -2,7 +2,7 @@
   "age": {
     "LongName": "age",
     "Description": "age of the participant",
-    "Units": "month"
+    "Units": "year"
   },
   "sex": {
     "LongName": "sex",


### PR DESCRIPTION
Prompted by checks in
- https://github.com/bids-standard/bids-specification/issues/1633#issuecomment-4253350012

Looking at the data suggests that it is very unlikely to be months since capped at 89+ and for ukb it was not on toddlers

    ❯ head -n 6 genetics_ukbb/participants.tsv
    participant_id	age	sex	group	genetic_id	IDH	BatchID	VariationSetType	Assembly	GeneticDataType
    sub-01	48	M	patient	125425	yes	b001	CNV	hg38	SNP_intensity
    sub-02	60	M	control	125698	no	b001	CNV	hg38	SNP_intensity
    sub-03	72	M	patient	452589	yes	b002	SNV/CNV	hg19/hg38	WES/SNP_intensity
    sub-04	84	F	patient	325478	no	b002	CNV	hg38	SNP_intensity
    sub-05	89+	M	control	623589	yes	b002	SNV/CNV	hg19/hg38	WES/SNP_intensity
