### PR TITLE
Add rich to dependencies

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,4 @@
 pybids  
 pandas
+rich
 tabulate


### PR DESCRIPTION
~~not sure how otherwise it was intended to work -- probably just some side effect on ci~~ later saw uv header with requirements... but I think docs just suggest running it and there are requirements.txt ... duplication is evil!

    ❯ rm -rf .venv && uv venv && source .venv/bin/activate && uv pip install -r tools/requirements.txt && python tools/print_dataset_listing.py
    Using CPython 3.11.12
    Creating virtual environment at: .venv
    Activate with: source .venv/bin/activate
    Resolved 28 packages in 19ms
    Installed 28 packages in 60ms
     + acres==0.5.0
     + bids-validator==1.14.7.post0 + bidsschematools==1.2.2 + click==8.3.2 + docopt==0.6.2 + formulaic==1.2.1 + frozendict==2.4.7 + fsspec==2026.3.0 + greenlet==3.4.0 + importlib-resources==7.1.0 + interface-meta==1.3.0 + narwhals==2.19.0 + nibabel==5.4.2 + num2words==0.5.14 + numpy==2.4.4 + packaging==26.1 + pandas==3.0.2 + pathlib-abc==0.5.2 + pybids==0.22.0 + python-dateutil==2.9.0.post0 + pyyaml==6.0.3 + scipy==1.17.1 + six==1.17.0 + sqlalchemy==2.0.49 + tabulate==0.10.0 + typing-extensions==4.15.0 + universal-pathlib==0.3.10 + wrapt==2.1.2 Traceback (most recent call last): File "/home/yoh/proj/bids/bids-examples/tools/print_dataset_listing.py", line 23, in <module> from rich import print ModuleNotFoundError: No module named 'rich'
